### PR TITLE
[FIX-001] Remove Node 18.x from CI matrix (Firebase requires 20+)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [20.x]
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
## Problem
Firebase SDK v12.4.0+ requires Node.js 20.0.0 or higher, causing Dependabot PRs to fail with EBADENGINE warnings on the Node 18.x build job.

## Solution
Remove Node 18.x from the CI test matrix, keeping only 20.x.

## Impact
- ✅ Dependabot PRs will now pass CI
- ✅ Aligns with `NODE_VERSION=20.x` repository variable
- ✅ No functional changes to codebase

## Testing
After merge, Dependabot PRs #6, #7, #8 will automatically re-run and should pass.