### PR TITLE
Fix clean build without runtime secrets

### DIFF
--- a/src/app/jobs/page.tsx
+++ b/src/app/jobs/page.tsx
@@ -39,6 +39,11 @@ export const metadata: Metadata = {
 async function getPublishedJobs(): Promise<{ jobs: Job[]; total: number }> {
   try {
     // In production, use absolute URL; in development, use localhost
+    const configuredBaseUrl = process.env.VERCEL_URL || process.env.NEXT_PUBLIC_APP_URL
+    if (!configuredBaseUrl && process.env.NODE_ENV === 'production') {
+      return { jobs: [], total: 0 }
+    }
+
     const baseUrl =
       process.env.VERCEL_URL
         ? `https://${process.env.VERCEL_URL}`

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,6 +1,6 @@
 import { MetadataRoute } from 'next'
 
-import { adminDb } from '@/lib/firebase/admin'
+import { adminDb, isFirebaseAdminFallbackMode } from '@/lib/firebase/admin'
 
 /**
  * Generate sitemap for Google Search Console
@@ -75,6 +75,10 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
  * Fetch all published job IDs and update timestamps from Firestore
  */
 async function getPublishedJobIds(): Promise<Array<{ id: string; updatedAt: Date }>> {
+  if (isFirebaseAdminFallbackMode) {
+    return []
+  }
+
   try {
     const snapshot = await adminDb
       .collection('jobs')

--- a/src/lib/config/env-validator.ts
+++ b/src/lib/config/env-validator.ts
@@ -282,29 +282,7 @@ export function getEnvSummary(): string {
   return lines.join('\n')
 }
 
-/**
- * Validates environment variables at module import time (server-side only)
- *
- * This ensures that missing configuration is detected immediately when the
- * application starts, rather than at runtime when a feature is first used.
- *
- * Only runs on server-side to avoid breaking client-side builds.
- */
-if (typeof window === 'undefined') {
-  try {
-    validateAllEnv()
-    console.log('✅ Environment validation passed')
-  } catch (error) {
-    // In development, log error but don't crash (for better DX)
-    // In production, crash immediately to prevent deployment with missing config
-    if (process.env.NODE_ENV === 'production') {
-      console.error('❌ Environment validation failed (production mode - will exit)')
-      console.error(error instanceof Error ? error.message : String(error))
-      process.exit(1)
-    } else {
-      console.warn('⚠️  Environment validation failed (development mode - continuing anyway)')
-      console.warn(error instanceof Error ? error.message : String(error))
-      console.warn('\nRun `npm run validate-env` to check your .env.local configuration')
-    }
-  }
-}
+// Do not validate at module import time. Next.js imports route modules during
+// production builds, and clean CI/build environments often do not have runtime
+// secrets available. Call validateAllEnv() explicitly from startup scripts,
+// deployment checks, or health diagnostics when validation is required.

--- a/src/lib/firebase/admin.ts
+++ b/src/lib/firebase/admin.ts
@@ -55,7 +55,6 @@ function validateFirebaseAdminConfig(params: { hasServiceAccount: boolean; allow
   }
 }
 
-const isServerEnvironment = typeof window === 'undefined'
 const rawPrivateKey = process.env.FIREBASE_PRIVATE_KEY ?? ''
 
 // Check for fallback mode FIRST (before validating service account)
@@ -73,12 +72,17 @@ const hasServiceAccount =
   rawPrivateKey.includes('END PRIVATE KEY') &&
   Boolean(process.env.FIREBASE_CLIENT_EMAIL)
 
-// Validate configuration on module import (server-side only)
-if (isServerEnvironment) {
+const configuredProjectId = process.env.FIREBASE_PROJECT_ID ?? 'demo-shopmatch-pro'
+
+let app: App | null = null
+
+export function getFirebaseAdminApp(): App {
+  if (app) return app
+
   validateFirebaseAdminConfig({ hasServiceAccount, allowFallback })
 
-  // SECURITY: Fail closed in production when credentials are missing
-  // Allow fallback mode in CI even during production builds (for build-time checks)
+  // SECURITY: Fail closed in production when credentials are missing.
+  // Allow fallback mode in CI even during production builds.
   if (!hasServiceAccount && process.env.NODE_ENV === 'production' && !allowFallback) {
     throw new Error(
       'CRITICAL: Firebase Admin credentials are missing in production environment. ' +
@@ -94,27 +98,27 @@ if (isServerEnvironment) {
       'Set FIREBASE_PRIVATE_KEY (with BEGIN/END PRIVATE KEY) to enable full functionality.'
     )
   }
-}
 
-const configuredProjectId = process.env.FIREBASE_PROJECT_ID ?? 'demo-shopmatch-pro'
-
-const app: App = getApps().length === 0
-  ? initializeApp(
-      hasServiceAccount
-        ? {
-            credential: cert({
+  app = getApps().length === 0
+    ? initializeApp(
+        hasServiceAccount
+          ? {
+              credential: cert({
+                projectId: configuredProjectId,
+                clientEmail: process.env.FIREBASE_CLIENT_EMAIL!,
+                // Handle both escaped newlines (\n as string) and actual newlines
+                privateKey: rawPrivateKey.replace(/\\n/g, '\n'),
+              }),
               projectId: configuredProjectId,
-              clientEmail: process.env.FIREBASE_CLIENT_EMAIL!,
-              // Handle both escaped newlines (\n as string) and actual newlines
-              privateKey: rawPrivateKey.replace(/\\n/g, '\n'),
-            }),
-            projectId: configuredProjectId,
-          }
-        : {
-            projectId: configuredProjectId,
-          },
-    )
-  : getApps()[0]!
+            }
+          : {
+              projectId: configuredProjectId,
+            },
+      )
+    : getApps()[0]!
+
+  return app
+}
 
 /**
  * Firebase Admin Authentication service instance
@@ -145,7 +149,17 @@ const app: App = getApps().length === 0
  *
  * @see https://firebase.google.com/docs/auth/admin/custom-claims
  */
-export const adminAuth = getAuth(app)
+export function getAdminAuth() {
+  return getAuth(getFirebaseAdminApp())
+}
+
+export const adminAuth = new Proxy({} as ReturnType<typeof getAuth>, {
+  get(_target, prop, receiver) {
+    const auth = getAdminAuth()
+    const value = Reflect.get(auth, prop, receiver)
+    return typeof value === 'function' ? value.bind(auth) : value
+  },
+})
 
 /**
  * Firebase Admin Firestore service instance
@@ -174,7 +188,17 @@ export const adminAuth = getAuth(app)
  *
  * @see https://firebase.google.com/docs/firestore/admin/manage-data
  */
-export const adminDb = getFirestore(app)
+export function getAdminDb() {
+  return getFirestore(getFirebaseAdminApp())
+}
+
+export const adminDb = new Proxy({} as ReturnType<typeof getFirestore>, {
+  get(_target, prop, receiver) {
+    const db = getAdminDb()
+    const value = Reflect.get(db, prop, receiver)
+    return typeof value === 'function' ? value.bind(db) : value
+  },
+})
 
 export const isFirebaseAdminFallbackMode = !hasServiceAccount
 
@@ -188,4 +212,12 @@ export const isFirebaseAdminFallbackMode = !hasServiceAccount
  * - Advanced security rules testing
  * - Integration with other Firebase services
  */
-export default app
+const adminApp = new Proxy({} as App, {
+  get(_target, prop, receiver) {
+    const adminApp = getFirebaseAdminApp()
+    const value = Reflect.get(adminApp, prop, receiver)
+    return typeof value === 'function' ? value.bind(adminApp) : value
+  },
+})
+
+export default adminApp

--- a/src/lib/firebase/client.ts
+++ b/src/lib/firebase/client.ts
@@ -11,7 +11,7 @@
  * - Compatible with Next.js SSR and client-side rendering
  */
 
-import { initializeApp, getApps } from 'firebase/app'
+import { initializeApp, getApps, type FirebaseApp } from 'firebase/app'
 import { getAuth } from 'firebase/auth'
 import { getFirestore } from 'firebase/firestore'
 
@@ -23,24 +23,46 @@ import { getFirestore } from 'firebase/firestore'
  * - Never exposes sensitive server-side keys to the client bundle
  * - Required for Firebase services to function in browser environment
  */
-const firebaseConfig = {
-  // API key for Firebase services (safe for client-side)
-  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+function getFirebaseConfig() {
+  const config = {
+    // API key for Firebase services (safe for client-side)
+    apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
 
-  // Authentication domain (safe for client-side)
-  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+    // Authentication domain (safe for client-side)
+    authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
 
-  // Project identifier (safe for client-side)
-  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+    // Project identifier (safe for client-side)
+    projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
 
-  // Cloud Storage bucket (safe for client-side)
-  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
+    // Cloud Storage bucket (safe for client-side)
+    storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
 
-  // Cloud Messaging sender ID (safe for client-side)
-  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
+    // Cloud Messaging sender ID (safe for client-side)
+    messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
 
-  // Firebase App ID (safe for client-side)
-  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
+    // Firebase App ID (safe for client-side)
+    appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
+  }
+
+  const missing = Object.entries(config)
+    .filter(([, value]) => !value)
+    .map(([name]) => name)
+
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing required Firebase client environment variables: ${missing.join(', ')}. ` +
+      'Set NEXT_PUBLIC_FIREBASE_* values before using Firebase client services.'
+    )
+  }
+
+  return config as {
+    apiKey: string
+    authDomain: string
+    projectId: string
+    storageBucket: string
+    messagingSenderId: string
+    appId: string
+  }
 }
 
 /**
@@ -54,7 +76,14 @@ const firebaseConfig = {
  *
  * @returns Firebase app instance (new or existing)
  */
-const app = getApps().length === 0 ? initializeApp(firebaseConfig) : getApps()[0]
+let app: FirebaseApp | null = null
+
+export function getFirebaseClientApp(): FirebaseApp {
+  if (app) return app
+
+  app = getApps().length === 0 ? initializeApp(getFirebaseConfig()) : getApps()[0]!
+  return app
+}
 
 /**
  * Firebase Authentication service instance
@@ -74,7 +103,17 @@ const app = getApps().length === 0 ? initializeApp(firebaseConfig) : getApps()[0
  * await signInWithEmailAndPassword(auth, email, password)
  * ```
  */
-export const auth = getAuth(app)
+export function getFirebaseAuth() {
+  return getAuth(getFirebaseClientApp())
+}
+
+export const auth = new Proxy({} as ReturnType<typeof getAuth>, {
+  get(_target, prop, receiver) {
+    const firebaseAuth = getFirebaseAuth()
+    const value = Reflect.get(firebaseAuth, prop, receiver)
+    return typeof value === 'function' ? value.bind(firebaseAuth) : value
+  },
+})
 
 /**
  * Cloud Firestore database service instance
@@ -94,7 +133,17 @@ export const auth = getAuth(app)
  * const querySnapshot = await getDocs(jobsRef)
  * ```
  */
-export const db = getFirestore(app)
+export function getFirebaseDb() {
+  return getFirestore(getFirebaseClientApp())
+}
+
+export const db = new Proxy({} as ReturnType<typeof getFirestore>, {
+  get(_target, prop, receiver) {
+    const firestore = getFirebaseDb()
+    const value = Reflect.get(firestore, prop, receiver)
+    return typeof value === 'function' ? value.bind(firestore) : value
+  },
+})
 
 /**
  * Default Firebase app export for advanced use cases
@@ -105,4 +154,12 @@ export const db = getFirestore(app)
  * - Custom Firebase service initialization
  * - Testing and mocking scenarios
  */
-export default app
+const firebaseApp = new Proxy({} as FirebaseApp, {
+  get(_target, prop, receiver) {
+    const clientApp = getFirebaseClientApp()
+    const value = Reflect.get(clientApp, prop, receiver)
+    return typeof value === 'function' ? value.bind(clientApp) : value
+  },
+})
+
+export default firebaseApp

--- a/src/lib/stripe/config.ts
+++ b/src/lib/stripe/config.ts
@@ -15,36 +15,34 @@
 import { Stripe } from 'stripe'
 
 /**
- * Validate Stripe environment variables
+ * Require a Stripe environment variable at runtime.
  *
- * Ensures all required Stripe configuration is present before initializing.
- * Provides clear error messages for missing configuration.
+ * Next.js imports route modules during production builds, so Stripe
+ * configuration must be validated when payment code runs, not when this module
+ * is imported.
  */
-function validateStripeConfig(): void {
-  const missing: string[] = []
+function requireStripeEnv(name: 'STRIPE_SECRET_KEY' | 'STRIPE_PRICE_ID_PRO' | 'STRIPE_WEBHOOK_SECRET'): string {
+  const value = process.env[name]
 
-  if (!process.env.STRIPE_SECRET_KEY) {
-    missing.push('STRIPE_SECRET_KEY')
-  }
-  if (!process.env.STRIPE_PRICE_ID_PRO) {
-    missing.push('STRIPE_PRICE_ID_PRO')
-  }
-  if (!process.env.STRIPE_WEBHOOK_SECRET) {
-    missing.push('STRIPE_WEBHOOK_SECRET')
-  }
-
-  if (missing.length > 0) {
+  if (!value) {
     throw new Error(
-      `Missing required Stripe environment variables: ${missing.join(', ')}.\n` +
+      `Missing required Stripe environment variable: ${name}.\n` +
       'Please check your .env.local file and ensure all Stripe configuration is set.\n' +
       'Run "npm run validate-env" for detailed validation.'
     )
   }
+
+  return value
 }
 
-// Validate configuration on module import (server-side only)
-if (typeof window === 'undefined') {
-  validateStripeConfig()
+let stripeClient: Stripe | null = null
+
+export function getStripeClient(): Stripe {
+  if (!stripeClient) {
+    stripeClient = new Stripe(requireStripeEnv('STRIPE_SECRET_KEY'))
+  }
+
+  return stripeClient
 }
 
 /**
@@ -72,7 +70,13 @@ if (typeof window === 'undefined') {
  * })
  * ```
  */
-export const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!)
+export const stripe = new Proxy({} as Stripe, {
+  get(_target, prop, receiver) {
+    const client = getStripeClient()
+    const value = Reflect.get(client, prop, receiver)
+    return typeof value === 'function' ? value.bind(client) : value
+  },
+})
 
 /**
  * Stripe configuration constants
@@ -94,9 +98,11 @@ export const STRIPE_CONFIG = {
    * Security: Price IDs are not sensitive and can be safely exposed to the client.
    * Uses NEXT_PUBLIC_ prefix for client-side access, falls back to server-only var.
    */
-  PRO_PRICE_ID: (typeof window === 'undefined'
-    ? process.env.STRIPE_PRICE_ID_PRO
-    : process.env.NEXT_PUBLIC_STRIPE_PRICE_ID_PRO) || process.env.STRIPE_PRICE_ID_PRO!,
+  get PRO_PRICE_ID() {
+    return (typeof window === 'undefined'
+      ? process.env.STRIPE_PRICE_ID_PRO
+      : process.env.NEXT_PUBLIC_STRIPE_PRICE_ID_PRO) || requireStripeEnv('STRIPE_PRICE_ID_PRO')
+  },
 
   /**
    * Webhook endpoint secret for signature verification
@@ -110,7 +116,9 @@ export const STRIPE_CONFIG = {
    *
    * @see https://docs.stripe.com/webhooks
    */
-  WEBHOOK_SECRET: process.env.STRIPE_WEBHOOK_SECRET!,
+  get WEBHOOK_SECRET() {
+    return requireStripeEnv('STRIPE_WEBHOOK_SECRET')
+  },
 
   /**
    * Stripe API version for compatibility
@@ -157,7 +165,9 @@ export const SUBSCRIPTION_TIERS = {
     id: 'pro',
     name: 'ShopMatch Pro',
     description: 'Post unlimited jobs and manage applications',
-    priceId: STRIPE_CONFIG.PRO_PRICE_ID,
+    get priceId() {
+      return STRIPE_CONFIG.PRO_PRICE_ID
+    },
   },
 } as const
 


### PR DESCRIPTION
## Summary
- defer Firebase client/admin and Stripe initialization until runtime use
- remove import-time env validation side effects from the health validator module
- avoid build-time self-fetch/no-credential sitemap noise on clean builds

## Verification
- npm audit --omit=dev
- npm run lint
- npm run typecheck
- npm run build
- npm run test:unit