### PR TITLE
fix(api): make application submission transactional and counters atomic

### DIFF
--- a/src/app/api/jobs/[id]/apply/route.ts
+++ b/src/app/api/jobs/[id]/apply/route.ts
@@ -1,3 +1,4 @@
+import { FieldValue } from 'firebase-admin/firestore'
 import { NextResponse } from 'next/server'
 
 import { assertRole, verifyAuth } from '@/lib/api/auth'
@@ -34,61 +35,71 @@ export async function POST(request: Request, context: RouteContext) {
       throw new ApiError('Validation failed', 422, parsed.error.format())
     }
 
-    // Fetch job to verify it exists and is published
-    const jobRef = adminDb.collection('jobs').doc(jobId)
-    const jobDoc = await jobRef.get()
-
-    if (!jobDoc.exists) {
-      throw new ApiError('Job not found', 404)
-    }
-
-    const job = jobDoc.data()!
-    if (job.status !== 'published') {
-      throw new ApiError('This job is not accepting applications', 400)
-    }
-
-    // Check if user has already applied
-    const existingApplications = await adminDb
-      .collection('applications')
-      .where('jobId', '==', jobId)
-      .where('seekerId', '==', auth.uid)
-      .limit(1)
-      .get()
-
-    if (!existingApplications.empty) {
-      throw new ApiError('You have already applied to this job', 400)
-    }
-
     // Get seeker details
     const userRecord = await adminAuth.getUser(auth.uid)
 
-    // Create application
+    const jobRef = adminDb.collection('jobs').doc(jobId)
+    // Deterministic ID makes a duplicate application a same-document conflict
+    const appRef = adminDb.collection('applications').doc(`${jobId}_${auth.uid}`)
     const now = new Date()
-    const applicationData = {
-      jobId,
-      seekerId: auth.uid,
-      ownerId: job.ownerId,
-      coverLetter: parsed.data.coverLetter || null,
-      phone: parsed.data.phone || null,
-      jobTitle: job.title,
-      company: job.company,
-      seekerName: userRecord.displayName || 'Anonymous',
-      seekerEmail: userRecord.email || '',
-      status: 'pending' as const,
-      createdAt: now,
-      updatedAt: now,
-    }
 
-    const applicationsRef = adminDb.collection('applications')
-    const docRef = await applicationsRef.add(applicationData)
+    // Create application and increment the counter atomically
+    await adminDb.runTransaction(async (transaction) => {
+      // Firestore transactions require all reads before any writes
+      const jobDoc = await transaction.get(jobRef)
 
-    // Increment job application count
-    await jobRef.update({
-      applicationCount: (job.applicationCount ?? 0) + 1,
+      if (!jobDoc.exists) {
+        throw new ApiError('Job not found', 404)
+      }
+
+      const job = jobDoc.data()!
+      if (job.status !== 'published') {
+        throw new ApiError('This job is not accepting applications', 400)
+      }
+
+      // Check if user has already applied
+      const existingAppDoc = await transaction.get(appRef)
+      if (existingAppDoc.exists) {
+        throw new ApiError('You have already applied to this job', 400)
+      }
+
+      // Legacy applications have auto-generated IDs, so the deterministic-ID
+      // check above cannot detect them — query by jobId/seekerId as well
+      const existingApplications = await transaction.get(
+        adminDb
+          .collection('applications')
+          .where('jobId', '==', jobId)
+          .where('seekerId', '==', auth.uid)
+          .limit(1),
+      )
+
+      if (!existingApplications.empty) {
+        throw new ApiError('You have already applied to this job', 400)
+      }
+
+      const applicationData = {
+        jobId,
+        seekerId: auth.uid,
+        ownerId: job.ownerId,
+        coverLetter: parsed.data.coverLetter || null,
+        phone: parsed.data.phone || null,
+        jobTitle: job.title,
+        company: job.company,
+        seekerName: userRecord.displayName || 'Anonymous',
+        seekerEmail: userRecord.email || '',
+        status: 'pending' as const,
+        createdAt: now,
+        updatedAt: now,
+      }
+
+      transaction.create(appRef, applicationData)
+      transaction.update(jobRef, {
+        applicationCount: FieldValue.increment(1),
+      })
     })
 
     // Retrieve the created application
-    const appDoc = await docRef.get()
+    const appDoc = await appRef.get()
     const application: Application = {
       id: appDoc.id,
       ...appDoc.data(),

--- a/src/app/api/jobs/[id]/route.ts
+++ b/src/app/api/jobs/[id]/route.ts
@@ -1,3 +1,4 @@
+import { FieldValue } from 'firebase-admin/firestore'
 import { NextResponse } from 'next/server'
 
 import { assertActiveSubscription, verifyAuth } from '@/lib/api/auth'
@@ -53,7 +54,7 @@ export async function GET(request: Request, context: RouteContext) {
     // Increment view count for published jobs
     if (jobData.status === 'published') {
       await jobRef.update({
-        viewCount: (jobData.viewCount ?? 0) + 1,
+        viewCount: FieldValue.increment(1),
       })
     }
 


### PR DESCRIPTION
## Summary

PR 3A of the cleanup roadmap (correctness-only; the server data-layer extraction is deferred to PR 3B so this stays small and reviewable).

### Problems fixed

1. **Duplicate-application race**: the apply route ran its duplicate check, the application create, and the `applicationCount` increment as three separate operations. Two concurrent submissions could both pass the check and both create applications.
2. **Lost counter updates**: `applicationCount` and `viewCount` used read-modify-write (`count + 1`), so concurrent increments clobbered each other.

### Changes

- `POST /api/jobs/[id]/apply` now runs all Firestore reads and writes in a single `adminDb.runTransaction()`: job existence/published checks, both duplicate checks, the application create, and the counter increment commit or abort together.
- New applications use a **deterministic document ID** (`{jobId}_{seekerId}`), making a duplicate submission a same-document conflict that `transaction.create()` rejects atomically. The legacy `jobId`/`seekerId` query check is kept inside the transaction because existing applications have random auto-IDs.
- `applicationCount` and the job-detail `viewCount` use `FieldValue.increment(1)`.

Response shapes, status codes, error messages, and document fields are unchanged.

### Verification

- `npm run lint` ✅ · `npm run typecheck` ✅ · `npm run build` ✅

## Sequencing

Merge after #188 (Firestore rules v2). No file overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)