### PR TITLE
fix(stripe): add webhook event idempotency and rethrow processing failures

### DIFF
--- a/scripts/reconcile-subscriptions.js
+++ b/scripts/reconcile-subscriptions.js
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+
+/**
+ * Subscription Reconciliation Script for ShopMatch Pro
+ *
+ * Stripe webhooks keep subscription entitlements (users/{uid}.subActive and
+ * the subActive custom claim) in sync with Stripe. If a webhook was missed
+ * or its processing failed, a paying customer can lose access — or a lapsed
+ * one keep it — silently. This script detects and repairs that drift.
+ *
+ * For every user with a stripeCustomerId this script:
+ * - Lists their subscriptions from Stripe
+ * - Derives the expected subActive using the same status definition as the
+ *   webhook handler (only status === 'active' grants access)
+ * - Compares against the users/{uid} document and the Auth custom claims
+ * - Reports mismatches, and fixes both unless --dry-run
+ *
+ * Usage:
+ *   node scripts/reconcile-subscriptions.js            # apply fixes
+ *   node scripts/reconcile-subscriptions.js --dry-run  # report only, change nothing
+ *
+ * Requirements:
+ * - Proper authentication (gcloud CLI or service account)
+ * - Environment variables configured (.env.local), including STRIPE_SECRET_KEY
+ *
+ * Note: Fixed users must refresh their ID token (sign out/in, or
+ * user.getIdToken(true)) before new claims take effect client-side.
+ */
+
+/* eslint-disable @typescript-eslint/no-require-imports */
+require('dotenv').config({ path: '.env.local' })
+
+const { initializeApp, getApps, cert } = require('firebase-admin/app')
+const { getAuth } = require('firebase-admin/auth')
+const { getFirestore } = require('firebase-admin/firestore')
+const Stripe = require('stripe')
+
+const DRY_RUN = process.argv.includes('--dry-run')
+
+/**
+ * Initialize Firebase Admin SDK (ADC first, service account fallback)
+ */
+function initializeFirebaseAdmin() {
+  if (getApps().length > 0) {
+    return getApps()[0]
+  }
+
+  const projectId = process.env.FIREBASE_PROJECT_ID
+
+  if (!projectId) {
+    throw new Error('FIREBASE_PROJECT_ID environment variable is required')
+  }
+
+  console.log(`🔥 Initializing Firebase Admin for project: ${projectId}`)
+
+  try {
+    const app = initializeApp({ projectId })
+    console.log('✅ Using Application Default Credentials (gcloud CLI)')
+    return app
+  } catch {
+    console.log('⚠️ ADC failed, trying service account credentials...')
+
+    const clientEmail = process.env.FIREBASE_CLIENT_EMAIL
+    const privateKey = process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n')
+
+    if (!clientEmail || !privateKey) {
+      throw new Error(
+        'Neither ADC nor service account credentials available. ' +
+        'Run: gcloud auth application-default login'
+      )
+    }
+
+    const app = initializeApp({
+      credential: cert({ projectId, clientEmail, privateKey }),
+    })
+    console.log('✅ Using service account credentials')
+    return app
+  }
+}
+
+/**
+ * Expected subActive for a Stripe customer. Mirrors handleSubscriptionUpdate
+ * in src/app/api/stripe/webhook/route.ts: only a subscription with
+ * status === 'active' grants access.
+ */
+async function expectedSubActiveFor(stripe, customerId) {
+  const subscriptions = await stripe.subscriptions.list({
+    customer: customerId,
+    status: 'all',
+    limit: 10,
+  })
+
+  return subscriptions.data.some((subscription) => subscription.status === 'active')
+}
+
+async function reconcile() {
+  if (!process.env.STRIPE_SECRET_KEY) {
+    throw new Error('STRIPE_SECRET_KEY environment variable is required')
+  }
+
+  const app = initializeFirebaseAdmin()
+  const auth = getAuth(app)
+  const db = getFirestore(app)
+  const stripe = new Stripe(process.env.STRIPE_SECRET_KEY)
+
+  console.log(`\n${DRY_RUN ? '🔍 DRY RUN — no changes will be made' : '🚀 Reconciling subscription entitlements'}\n`)
+
+  // No index supports a stripeCustomerId != null query (see
+  // firestore.indexes.json), so fetch all users and filter in memory
+  console.log('📥 Fetching all users and filtering for stripeCustomerId in memory (no != index)')
+  const snapshot = await db.collection('users').get()
+  const usersWithCustomer = snapshot.docs.filter((doc) => doc.data().stripeCustomerId)
+
+  console.log(`   ${snapshot.size} users total, ${usersWithCustomer.length} with a stripeCustomerId\n`)
+
+  const stats = { checked: 0, inSync: 0, fixed: 0, errors: 0 }
+
+  for (const userDoc of usersWithCustomer) {
+    const uid = userDoc.id
+    const data = userDoc.data()
+    stats.checked++
+
+    try {
+      const expected = await expectedSubActiveFor(stripe, data.stripeCustomerId)
+
+      const userRecord = await auth.getUser(uid)
+      const existingClaims = userRecord.customClaims || {}
+
+      const docActive = data.subActive === true
+      const claimActive = existingClaims.subActive === true
+
+      if (docActive === expected && claimActive === expected) {
+        stats.inSync++
+        continue
+      }
+
+      console.log(
+        `   ${DRY_RUN ? 'would fix' : 'fixing'} ${data.email || uid} (${data.stripeCustomerId}): ` +
+        `expected subActive ${expected}, doc ${docActive}, claims ${claimActive}`
+      )
+
+      if (!DRY_RUN) {
+        await userDoc.ref.update({
+          subActive: expected,
+          updatedAt: new Date(),
+        })
+
+        // Preserve unrelated existing claims
+        await auth.setCustomUserClaims(uid, { ...existingClaims, subActive: expected })
+      }
+
+      stats.fixed++
+    } catch (error) {
+      stats.errors++
+      console.error(`   ❌ ${data.email || uid}:`, error.message || error)
+    }
+  }
+
+  console.log('\n📊 Summary')
+  console.log(`   checked:    ${stats.checked}`)
+  console.log(`   in sync:    ${stats.inSync}`)
+  console.log(`   ${DRY_RUN ? 'would fix' : 'fixed'}:  ${stats.fixed}`)
+  console.log(`   errors:     ${stats.errors}`)
+
+  if (stats.fixed > 0 && !DRY_RUN) {
+    console.log('\n💡 Fixed users must refresh their ID token (sign out/in) for new claims to apply.')
+  }
+}
+
+reconcile().catch((error) => {
+  console.error('\n❌ Reconciliation failed:', error)
+  process.exit(1)
+})

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -89,8 +89,27 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       )
     }
 
+    // Idempotency guard: Stripe retries failed deliveries and can also send
+    // duplicates, so skip events that have already been fully processed
+    const eventRef = adminDb.collection('processedStripeEvents').doc(event.id)
+    const processedEvent = await eventRef.get()
+
+    if (processedEvent.exists) {
+      console.log(`Skipping already-processed event ${event.id} (${event.type})`)
+      return NextResponse.json({ received: true })
+    }
+
     // Process the verified event
     await processWebhookEvent(event)
+
+    // Mark the event as processed only after success so failed events are
+    // retried. The small race between check and write is acceptable: the
+    // event handlers set absolute values (not deltas), so reprocessing a
+    // duplicate is harmless.
+    await eventRef.set({
+      type: event.type,
+      processedAt: new Date(),
+    })
 
     // Return success response to Stripe
     return NextResponse.json({ received: true })
@@ -134,11 +153,14 @@ async function processWebhookEvent(event: { type: string; data: { object: unknow
         break
 
       default:
+        // No-op: unhandled event types must not throw, or Stripe would
+        // retry them pointlessly for days
         console.log(`Unhandled event type: ${event.type}`)
     }
   } catch (error: unknown) {
     console.error(`Error processing ${event.type}:`, error)
-    // Don't throw - allow webhook to return success to prevent retries
+    // Rethrow so the POST handler returns 500 and Stripe retries the event
+    throw error
   }
 }
 


### PR DESCRIPTION
## Summary

PR 4 of the cleanup roadmap. Ships the webhook rethrow and event idempotency **together** (atomically, per the agreed constraint — rethrow alone would invite retry storms, idempotency alone would leave the dead retry path).

### The bug

`processWebhookEvent()` caught and swallowed all handler errors ("Don't throw - allow webhook to return success to prevent retries"), while the inner event handlers dutifully rethrew into that catch. Net effect: the POST handler's 500-for-Stripe-retry path was dead code. If setting the `subActive` custom claim failed after a successful payment, the webhook still returned 200, Stripe never retried, and a **paying customer silently ended up without access**.

### Changes

- `processWebhookEvent()` now rethrows, so failed events return 500 and Stripe redelivers. Unhandled event types remain a no-op log (they must not throw or they'd retry pointlessly for days).
- Idempotency guard: after signature verification, the handler checks `processedStripeEvents/{event.id}` and returns 200 immediately for already-processed events. The marker is written **only after successful processing**, so failed events are reprocessed on retry. The check-then-write race is acceptable because handlers set absolute values, not deltas. (`processedStripeEvents` is server-only — Firestore rules deny unmatched paths by default.)
- `scripts/reconcile-subscriptions.js`: detects and repairs **existing** drift between Stripe subscriptions and Firebase entitlements (Firestore `subActive` + custom claims) — the damage this bug may already have caused. Mirrors the webhook's exact active-status definition (`status === 'active'`), preserves unrelated claims, supports `--dry-run`, follows the same conventions as `backfill-claims.js`.

### Verification

- `npm run lint` ✅ · `npm run typecheck` ✅ · `npm run build` ✅
- Webhook response shapes/status codes unchanged (200 `{received: true}`, 400 signature failure, 500 processing failure)

### Post-merge ops note

Worth running `node scripts/reconcile-subscriptions.js --dry-run` against production once credentials are available, alongside the claims backfill from #188.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
