### PR TITLE
ci(actions): skip commit message validation for Dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,13 @@ jobs:
         echo "Validating commit messages for PR #${{ github.event.pull_request.number }}"
         echo ""
 
+        # Skip validation for Dependabot PRs (auto-generated commit messages
+        # use the "deps" prefix), mirroring the branch name validation job
+        if [[ "${{ github.event.pull_request.head.ref }}" =~ ^dependabot/ ]]; then
+          echo "✅ SKIPPED: Dependabot PR (auto-generated commits)"
+          exit 0
+        fi
+
         # Get all commits in the PR
         BASE_SHA="${{ github.event.pull_request.base.sha }}"
         HEAD_SHA="${{ github.event.pull_request.head.sha }}"


### PR DESCRIPTION
The branch-name validation job skips \dependabot/\ branches, but the commit-message job did not — so every Dependabot PR fails 'Validate Commit Messages' on its auto-generated \deps(deps):\ prefix (e.g. #168, #170, #183, and the just-merged #193). This mirrors the same skip in the sibling job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)