### PR TITLE
refactor(server): extract server data layer from API routes (SMP-106)

### DIFF
--- a/docs/adr/0004-server-data-layer.md
+++ b/docs/adr/0004-server-data-layer.md
@@ -1,0 +1,27 @@
+# ADR 0004 — Server Data Layer under src/lib/server
+**Date:** 2026-06-10 · **Status:** Accepted
+
+## Context
+API route handlers had accumulated inline Firestore queries, four duplicated Timestamp-to-Date transforms, and persistence-coupled business rules. PRs #188–#191 hardened individual routes but increased the spread. No written spec existed for the planned "PR 3B server data-layer extraction"; this ADR records the design as implemented (SMP-106) so the decision lives in the repo.
+
+## Decision
+- All Firestore access for domain data lives in `src/lib/server/` modules: `jobs.ts`, `applications.ts`, `users.ts`, with shared helpers in `firestore.ts` (`toDateValue`, `isMissingIndexError`).
+- Route handlers keep HTTP concerns only: request parsing, Zod validation, auth guards, response shaping.
+- Boundary rule: `src/lib/api/` holds request-scoped guards and error mapping (`verifyAuth`, `assertRole`, `ApiError`, rate limiters); `src/lib/server/` holds data access. The two directories are intentional — do not merge them.
+- Data functions throw `ApiError` (status-bearing domain errors) for `handleApiError` to translate. Exception: the CSV export data function returns a discriminated result so the route can keep its distinct legacy 404 responses byte-identical.
+- Transaction semantics from #190 (atomic application create + counter increment, dual duplicate checks) moved verbatim into `submitApplication`.
+
+## Consequences
++ Single implementation of queries and transforms; transaction logic is unit-testable without HTTP plumbing
++ Route handlers shrank by roughly 580 lines with no contract change
+– `ApiError` couples the data layer to HTTP status semantics (accepted as pragmatic for this codebase size)
+– Stripe routes and `users/initialize-claims` still use the Admin SDK directly (deliberately out of scope; see follow-ups)
+
+## Alternatives
+Repository classes with dependency injection (rejected: overkill at this scale); keeping inline queries (rejected: duplication had already caused drift between the two job-transform copies).
+
+## Follow-ups
+- Convert the job detail page to SSR reusing `getJob` (the jobs list went SSR in #97; the detail page is the actual SEO target)
+- Reuse `listJobs` in `src/app/sitemap.ts`
+- Migrate the export route from manual token verification to `verifyAuth`
+- Replace in-memory rate limiting with a durable store (per-instance on Vercel today)

--- a/src/app/api/applications/[id]/route.ts
+++ b/src/app/api/applications/[id]/route.ts
@@ -2,9 +2,11 @@ import { NextResponse } from 'next/server'
 
 import { assertRole, verifyAuth } from '@/lib/api/auth'
 import { ApiError, handleApiError } from '@/lib/api/errors'
-import { adminDb } from '@/lib/firebase/admin'
+import {
+  getApplicationForParticipant,
+  updateApplicationStatus,
+} from '@/lib/server/applications'
 import { applicationStatusUpdateSchema } from '@/types'
-import type { Application } from '@/types'
 
 type RouteContext = {
   params: Promise<{
@@ -25,28 +27,7 @@ export async function GET(request: Request, context: RouteContext) {
 
     const auth = await verifyAuth(request)
 
-    // Fetch application
-    const appRef = adminDb.collection('applications').doc(id)
-    const doc = await appRef.get()
-
-    if (!doc.exists) {
-      throw new ApiError('Application not found', 404)
-    }
-
-    const appData = doc.data()!
-
-    // Ensure requester is either the seeker or the owner
-    if (appData.seekerId !== auth.uid && appData.ownerId !== auth.uid) {
-      throw new ApiError('You do not have permission to view this application', 403)
-    }
-
-    const application: Application = {
-      id: doc.id,
-      ...appData,
-      createdAt: appData.createdAt?.toDate?.() ?? appData.createdAt,
-      updatedAt: appData.updatedAt?.toDate?.() ?? appData.updatedAt,
-      reviewedAt: appData.reviewedAt?.toDate?.() ?? appData.reviewedAt,
-    } as Application
+    const application = await getApplicationForParticipant(id, auth.uid)
 
     return NextResponse.json({ application })
   } catch (error) {
@@ -74,44 +55,7 @@ export async function PATCH(request: Request, context: RouteContext) {
       throw new ApiError('Validation failed', 422, parsed.error.format())
     }
 
-    // Fetch application and verify ownership
-    const appRef = adminDb.collection('applications').doc(id)
-    const doc = await appRef.get()
-
-    if (!doc.exists) {
-      throw new ApiError('Application not found', 404)
-    }
-
-    const appData = doc.data()!
-
-    // Verify the authenticated owner manages the linked job
-    if (appData.ownerId !== auth.uid) {
-      throw new ApiError('You do not have permission to update this application', 403)
-    }
-
-    const now = new Date()
-    const updates: Partial<Application> = {
-      status: parsed.data.status,
-      notes: parsed.data.notes,
-      updatedAt: now,
-    }
-
-    // Set reviewedAt if status is being changed from pending and reviewedAt is not set
-    if (appData.status === 'pending' && parsed.data.status !== 'pending' && !appData.reviewedAt) {
-      updates.reviewedAt = now
-    }
-
-    await appRef.update(updates)
-
-    // Retrieve updated document
-    const updatedDoc = await appRef.get()
-    const application: Application = {
-      id: updatedDoc.id,
-      ...updatedDoc.data(),
-      createdAt: updatedDoc.data()?.createdAt?.toDate?.() ?? updatedDoc.data()?.createdAt,
-      updatedAt: updatedDoc.data()?.updatedAt?.toDate?.() ?? updatedDoc.data()?.updatedAt,
-      reviewedAt: updatedDoc.data()?.reviewedAt?.toDate?.() ?? updatedDoc.data()?.reviewedAt,
-    } as Application
+    const application = await updateApplicationStatus(id, auth.uid, parsed.data)
 
     return NextResponse.json({
       message: 'Application updated successfully',

--- a/src/app/api/applications/export/route.ts
+++ b/src/app/api/applications/export/route.ts
@@ -27,9 +27,11 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server'
-import { adminAuth, adminDb } from '@/lib/firebase/admin'
+import { adminAuth } from '@/lib/firebase/admin'
 import { csvExportLimiter } from '@/lib/api/rate-limit'
 import { toCSV, commonTransforms } from '@/lib/csv/to-csv'
+import { getOwnerApplicationsExportData } from '@/lib/server/applications'
+import { getUserRecordSummary } from '@/lib/server/users'
 
 export const runtime = 'nodejs' // Required for Firebase Admin SDK
 
@@ -54,16 +56,15 @@ export async function GET(request: NextRequest) {
     const userId = decodedToken.uid
 
     // 2. Verify user role (owner only)
-    const userDoc = await adminDb.collection('users').doc(userId).get()
-    if (!userDoc.exists) {
+    const user = await getUserRecordSummary(userId)
+    if (!user.exists) {
       return NextResponse.json(
         { error: 'User not found' },
         { status: 404 }
       )
     }
 
-    const userData = userDoc.data()
-    if (userData?.role !== 'owner') {
+    if (user.role !== 'owner') {
       return NextResponse.json(
         { error: 'Only job owners can export applications' },
         { status: 403 }
@@ -96,79 +97,34 @@ export async function GET(request: NextRequest) {
       )
     }
 
-    // 4. Fetch all jobs owned by user
-    const jobsSnapshot = await adminDb
-      .collection('jobs')
-      .where('ownerId', '==', userId)
-      .get()
+    // 4. Fetch applications, job titles, and seeker emails via the data layer
+    const exportData = await getOwnerApplicationsExportData(userId)
 
-    if (jobsSnapshot.empty) {
+    if (exportData.kind === 'no-jobs') {
       return NextResponse.json(
         { error: 'No jobs found', message: 'You have not posted any jobs yet' },
         { status: 404 }
       )
     }
 
-    const jobIds = jobsSnapshot.docs.map((doc) => doc.id)
-    const jobTitles = new Map(
-      jobsSnapshot.docs.map((doc) => [doc.id, doc.data().title])
-    )
-
-    // 5. Fetch all applications for these jobs
-    // Note: Firestore 'in' queries support up to 10 items, so batch if needed
-    const applicationsBatches: FirebaseFirestore.DocumentData[] = []
-
-    for (let i = 0; i < jobIds.length; i += 10) {
-      const batch = jobIds.slice(i, i + 10)
-      const applicationsSnapshot = await adminDb
-        .collection('applications')
-        .where('jobId', 'in', batch)
-        .orderBy('createdAt', 'desc')
-        .get()
-
-      applicationsBatches.push(...applicationsSnapshot.docs.map((doc) => ({
-        id: doc.id,
-        ...doc.data(),
-      })))
-    }
-
-    if (applicationsBatches.length === 0) {
+    if (exportData.kind === 'no-applications') {
       return NextResponse.json(
         { error: 'No applications found', message: 'No applications have been submitted to your jobs' },
         { status: 404 }
       )
     }
 
-    // 6. Fetch seeker details (email) for each application
-    const seekerIds = [...new Set(applicationsBatches.map((app) => app.seekerId))]
-    const seekersMap = new Map<string, { email: string }>()
-
-    for (const seekerId of seekerIds) {
-      try {
-        const seekerDoc = await adminDb.collection('users').doc(seekerId).get()
-        if (seekerDoc.exists) {
-          const seekerData = seekerDoc.data()
-          seekersMap.set(seekerId, {
-            email: seekerData?.email || 'N/A',
-          })
-        }
-      } catch (error) {
-        console.error(`Failed to fetch seeker ${seekerId}:`, error)
-        seekersMap.set(seekerId, { email: 'N/A' })
-      }
-    }
-
-    // 7. Map applications to CSV-friendly format
-    const csvData = applicationsBatches.map((app) => ({
-      jobTitle: jobTitles.get(app.jobId) || 'Unknown Job',
-      seekerEmail: seekersMap.get(app.seekerId)?.email || 'N/A',
+    // 5. Map applications to CSV-friendly format
+    const csvData = exportData.applications.map((app) => ({
+      jobTitle: exportData.jobTitles.get(app.jobId) || 'Unknown Job',
+      seekerEmail: exportData.seekers.get(app.seekerId)?.email || 'N/A',
       status: app.status,
       coverLetter: app.coverLetter || '',
       appliedAt: app.createdAt,
       lastUpdated: app.updatedAt,
     }))
 
-    // 8. Generate CSV
+    // 6. Generate CSV
     const csv = toCSV(csvData, {
       columns: {
         jobTitle: 'Job Title',
@@ -187,7 +143,7 @@ export async function GET(request: NextRequest) {
       addBOM: true,
     })
 
-    // 9. Return CSV file
+    // 7. Return CSV file
     const filename = `applications-export-${new Date().toISOString().split('T')[0]}.csv`
 
     return new NextResponse(csv, {

--- a/src/app/api/applications/route.ts
+++ b/src/app/api/applications/route.ts
@@ -2,18 +2,7 @@ import { NextResponse } from 'next/server'
 
 import { verifyAuth } from '@/lib/api/auth'
 import { ApiError, handleApiError } from '@/lib/api/errors'
-import { adminDb } from '@/lib/firebase/admin'
-import { applicationStatuses } from '@/types'
-import type { Application } from '@/types'
-
-type ApplicationListFilters = {
-  jobId?: string
-  seekerId?: string
-  ownerId?: string
-  status?: (typeof applicationStatuses)[number]
-  page: number
-  limit: number
-}
+import { listApplications, type ApplicationListFilters } from '@/lib/server/applications'
 
 function parseFilters(request: Request, userId: string): ApplicationListFilters {
   const url = new URL(request.url)
@@ -49,49 +38,7 @@ export async function GET(request: Request) {
     const auth = await verifyAuth(request)
     const filters = parseFilters(request, auth.uid)
 
-    const applicationsRef = adminDb.collection('applications')
-    let query: FirebaseFirestore.Query = applicationsRef
-
-    // Apply filters
-    if (filters.jobId) {
-      query = query.where('jobId', '==', filters.jobId)
-    }
-    if (filters.seekerId) {
-      query = query.where('seekerId', '==', filters.seekerId)
-    }
-    if (filters.ownerId) {
-      query = query.where('ownerId', '==', filters.ownerId)
-    }
-    if (filters.status) {
-      query = query.where('status', '==', filters.status)
-    }
-
-    // Order by creation date (descending)
-    query = query.orderBy('createdAt', 'desc')
-
-    // Pagination
-    const offset = (filters.page - 1) * filters.limit
-    query = query.limit(filters.limit).offset(offset)
-
-    const snapshot = await query.get()
-
-    // Get total count for pagination
-    let countQuery: FirebaseFirestore.Query = applicationsRef
-    if (filters.jobId) countQuery = countQuery.where('jobId', '==', filters.jobId)
-    if (filters.seekerId) countQuery = countQuery.where('seekerId', '==', filters.seekerId)
-    if (filters.ownerId) countQuery = countQuery.where('ownerId', '==', filters.ownerId)
-    if (filters.status) countQuery = countQuery.where('status', '==', filters.status)
-
-    const countSnapshot = await countQuery.count().get()
-    const total = countSnapshot.data().count
-
-    const applications: Application[] = snapshot.docs.map((doc) => ({
-      id: doc.id,
-      ...doc.data(),
-      createdAt: doc.data().createdAt?.toDate?.() ?? doc.data().createdAt,
-      updatedAt: doc.data().updatedAt?.toDate?.() ?? doc.data().updatedAt,
-      reviewedAt: doc.data().reviewedAt?.toDate?.() ?? doc.data().reviewedAt,
-    })) as Application[]
+    const { applications, total } = await listApplications(filters)
 
     return NextResponse.json({
       applications,

--- a/src/app/api/jobs/[id]/apply/route.ts
+++ b/src/app/api/jobs/[id]/apply/route.ts
@@ -1,11 +1,9 @@
-import { FieldValue } from 'firebase-admin/firestore'
 import { NextResponse } from 'next/server'
 
 import { assertRole, verifyAuth } from '@/lib/api/auth'
 import { ApiError, handleApiError } from '@/lib/api/errors'
-import { adminAuth, adminDb } from '@/lib/firebase/admin'
+import { submitApplication } from '@/lib/server/applications'
 import { applicationSubmissionSchema } from '@/types'
-import type { Application } from '@/types'
 
 type RouteContext = {
   params: Promise<{
@@ -35,78 +33,7 @@ export async function POST(request: Request, context: RouteContext) {
       throw new ApiError('Validation failed', 422, parsed.error.format())
     }
 
-    // Get seeker details
-    const userRecord = await adminAuth.getUser(auth.uid)
-
-    const jobRef = adminDb.collection('jobs').doc(jobId)
-    // Deterministic ID makes a duplicate application a same-document conflict
-    const appRef = adminDb.collection('applications').doc(`${jobId}_${auth.uid}`)
-    const now = new Date()
-
-    // Create application and increment the counter atomically
-    await adminDb.runTransaction(async (transaction) => {
-      // Firestore transactions require all reads before any writes
-      const jobDoc = await transaction.get(jobRef)
-
-      if (!jobDoc.exists) {
-        throw new ApiError('Job not found', 404)
-      }
-
-      const job = jobDoc.data()!
-      if (job.status !== 'published') {
-        throw new ApiError('This job is not accepting applications', 400)
-      }
-
-      // Check if user has already applied
-      const existingAppDoc = await transaction.get(appRef)
-      if (existingAppDoc.exists) {
-        throw new ApiError('You have already applied to this job', 400)
-      }
-
-      // Legacy applications have auto-generated IDs, so the deterministic-ID
-      // check above cannot detect them — query by jobId/seekerId as well
-      const existingApplications = await transaction.get(
-        adminDb
-          .collection('applications')
-          .where('jobId', '==', jobId)
-          .where('seekerId', '==', auth.uid)
-          .limit(1),
-      )
-
-      if (!existingApplications.empty) {
-        throw new ApiError('You have already applied to this job', 400)
-      }
-
-      const applicationData = {
-        jobId,
-        seekerId: auth.uid,
-        ownerId: job.ownerId,
-        coverLetter: parsed.data.coverLetter || null,
-        phone: parsed.data.phone || null,
-        jobTitle: job.title,
-        company: job.company,
-        seekerName: userRecord.displayName || 'Anonymous',
-        seekerEmail: userRecord.email || '',
-        status: 'pending' as const,
-        createdAt: now,
-        updatedAt: now,
-      }
-
-      transaction.create(appRef, applicationData)
-      transaction.update(jobRef, {
-        applicationCount: FieldValue.increment(1),
-      })
-    })
-
-    // Retrieve the created application
-    const appDoc = await appRef.get()
-    const application: Application = {
-      id: appDoc.id,
-      ...appDoc.data(),
-      createdAt: appDoc.data()?.createdAt?.toDate?.() ?? appDoc.data()?.createdAt,
-      updatedAt: appDoc.data()?.updatedAt?.toDate?.() ?? appDoc.data()?.updatedAt,
-      reviewedAt: appDoc.data()?.reviewedAt?.toDate?.() ?? appDoc.data()?.reviewedAt,
-    } as Application
+    const application = await submitApplication(jobId, auth.uid, parsed.data)
 
     return NextResponse.json(
       {

--- a/src/app/api/jobs/[id]/route.ts
+++ b/src/app/api/jobs/[id]/route.ts
@@ -1,11 +1,9 @@
-import { FieldValue } from 'firebase-admin/firestore'
 import { NextResponse } from 'next/server'
 
 import { assertActiveSubscription, verifyAuth } from '@/lib/api/auth'
 import { ApiError, handleApiError } from '@/lib/api/errors'
-import { adminDb } from '@/lib/firebase/admin'
+import { deleteJob, getJob, updateJob } from '@/lib/server/jobs'
 import { jobFormSchema } from '@/types'
-import type { Job } from '@/types'
 
 type RouteContext = {
   params: Promise<{
@@ -36,36 +34,7 @@ export async function GET(request: Request, context: RouteContext) {
       }
     }
 
-    // Fetch job from Firestore
-    const jobRef = adminDb.collection('jobs').doc(id)
-    const doc = await jobRef.get()
-
-    if (!doc.exists) {
-      throw new ApiError('Job not found', 404)
-    }
-
-    const jobData = doc.data()!
-
-    // Enforce draft visibility: only owner can view draft jobs
-    if (jobData.status === 'draft' && jobData.ownerId !== authUid) {
-      throw new ApiError('Job not found', 404)
-    }
-
-    // Increment view count for published jobs
-    if (jobData.status === 'published') {
-      await jobRef.update({
-        viewCount: FieldValue.increment(1),
-      })
-    }
-
-    const job: Job = {
-      id: doc.id,
-      ...jobData,
-      createdAt: jobData.createdAt?.toDate?.() ?? jobData.createdAt,
-      updatedAt: jobData.updatedAt?.toDate?.() ?? jobData.updatedAt,
-      publishedAt: jobData.publishedAt?.toDate?.() ?? jobData.publishedAt,
-      expiresAt: jobData.expiresAt?.toDate?.() ?? jobData.expiresAt,
-    } as Job
+    const job = await getJob(id, authUid)
 
     return NextResponse.json({ job })
   } catch (error) {
@@ -93,42 +62,7 @@ export async function PUT(request: Request, context: RouteContext) {
       throw new ApiError('Validation failed', 422, parsed.error.format())
     }
 
-    // Verify job exists and user is owner
-    const jobRef = adminDb.collection('jobs').doc(id)
-    const doc = await jobRef.get()
-
-    if (!doc.exists) {
-      throw new ApiError('Job not found', 404)
-    }
-
-    const existingJob = doc.data()!
-    if (existingJob.ownerId !== auth.uid) {
-      throw new ApiError('You do not have permission to update this job', 403)
-    }
-
-    const now = new Date()
-    const wasPublished = existingJob.status === 'published'
-    const isNowPublished = parsed.data.status === 'published'
-
-    const updates = {
-      ...parsed.data,
-      updatedAt: now,
-      // Set publishedAt only if transitioning from draft to published
-      ...((!wasPublished && isNowPublished) && { publishedAt: now }),
-    }
-
-    await jobRef.update(updates)
-
-    // Retrieve updated document
-    const updatedDoc = await jobRef.get()
-    const job: Job = {
-      id: updatedDoc.id,
-      ...updatedDoc.data(),
-      createdAt: updatedDoc.data()?.createdAt?.toDate?.() ?? updatedDoc.data()?.createdAt,
-      updatedAt: updatedDoc.data()?.updatedAt?.toDate?.() ?? updatedDoc.data()?.updatedAt,
-      publishedAt: updatedDoc.data()?.publishedAt?.toDate?.() ?? updatedDoc.data()?.publishedAt,
-      expiresAt: updatedDoc.data()?.expiresAt?.toDate?.() ?? updatedDoc.data()?.expiresAt,
-    } as Job
+    const job = await updateJob(id, auth.uid, parsed.data)
 
     return NextResponse.json({
       message: 'Job updated successfully',
@@ -147,28 +81,7 @@ export async function DELETE(request: Request, context: RouteContext) {
     const auth = await verifyAuth(request)
     assertActiveSubscription(auth)
 
-    // Verify job exists and user is owner
-    const jobRef = adminDb.collection('jobs').doc(id)
-    const doc = await jobRef.get()
-
-    if (!doc.exists) {
-      throw new ApiError('Job not found', 404)
-    }
-
-    const job = doc.data()!
-    if (job.ownerId !== auth.uid) {
-      throw new ApiError('You do not have permission to delete this job', 403)
-    }
-
-    // Delete the job document
-    await jobRef.delete()
-
-    // Optional: Delete associated applications (consider this for production)
-    // const applicationsRef = adminDb.collection('applications')
-    // const applicationsSnapshot = await applicationsRef.where('jobId', '==', id).get()
-    // const batch = adminDb.batch()
-    // applicationsSnapshot.docs.forEach(doc => batch.delete(doc.ref))
-    // await batch.commit()
+    await deleteJob(id, auth.uid)
 
     return NextResponse.json({
       message: 'Job deleted successfully',

--- a/src/app/api/jobs/route.ts
+++ b/src/app/api/jobs/route.ts
@@ -2,35 +2,9 @@ import { NextResponse } from 'next/server'
 
 import { assertActiveSubscription, verifyAuth } from '@/lib/api/auth'
 import { ApiError, handleApiError } from '@/lib/api/errors'
-import { adminDb, isFirebaseAdminFallbackMode } from '@/lib/firebase/admin'
-import { jobFormSchema, jobStatuses, jobTypes } from '@/types'
-import type { Job } from '@/types'
-
-type JobListFilters = {
-  ownerId?: string
-  status?: (typeof jobStatuses)[number]
-  type?: (typeof jobTypes)[number]
-  location?: string
-  remote?: boolean
-  experience?: 'entry' | 'mid' | 'senior' | 'lead'
-  page: number
-  limit: number
-}
-
-function isMissingIndexError(error: unknown): boolean {
-  if (!error || typeof error !== 'object') {
-    return false
-  }
-
-  const code = (error as { code?: unknown }).code
-  const message = (error as { message?: unknown }).message
-  const normalizedMessage = typeof message === 'string' ? message.toLowerCase() : ''
-
-  return (
-    (code === 9 || code === 'failed-precondition') &&
-    normalizedMessage.includes('requires an index')
-  )
-}
+import { isMissingIndexError } from '@/lib/server/firestore'
+import { createJob, listJobs, type JobListFilters } from '@/lib/server/jobs'
+import { jobFormSchema } from '@/types'
 
 function parseBoolean(value: string | null): boolean | undefined {
   if (value === null) return undefined
@@ -62,149 +36,6 @@ function parseFilters(request: Request): JobListFilters {
   }
 }
 
-function buildJobsQuery(filters: JobListFilters): FirebaseFirestore.Query {
-  let query: FirebaseFirestore.Query = adminDb.collection('jobs')
-
-  // For public listing, only show published jobs unless ownerId filter is present
-  if (filters.ownerId) {
-    query = query.where('ownerId', '==', filters.ownerId)
-  } else {
-    query = query.where('status', '==', 'published')
-  }
-
-  // Apply additional filters
-  if (filters.status && filters.ownerId) {
-    // Only allow status filter if user is filtering their own jobs
-    query = query.where('status', '==', filters.status)
-  }
-  if (filters.type) {
-    query = query.where('type', '==', filters.type)
-  }
-  if (filters.remote !== undefined) {
-    query = query.where('remote', '==', filters.remote)
-  }
-  if (filters.experience) {
-    query = query.where('experience', '==', filters.experience)
-  }
-
-  return query
-}
-
-function transformJobDocument(doc: FirebaseFirestore.DocumentSnapshot): Job {
-  const data = doc.data()!
-  // Convert Firestore Timestamps to ISO strings for JSON
-  return {
-    id: doc.id,
-    ...data,
-    createdAt: (data.createdAt as FirebaseFirestore.Timestamp)?.toDate?.() ?? data.createdAt,
-    updatedAt: (data.updatedAt as FirebaseFirestore.Timestamp)?.toDate?.() ?? data.updatedAt,
-    publishedAt: (data.publishedAt as FirebaseFirestore.Timestamp)?.toDate?.() ?? data.publishedAt,
-    expiresAt: (data.expiresAt as FirebaseFirestore.Timestamp)?.toDate?.() ?? data.expiresAt,
-  } as Job
-}
-
-async function handleLocationFiltering(
-  jobs: Job[],
-  totalQuery: FirebaseFirestore.Query,
-  location: string
-) {
-  const locationLower = location.toLowerCase()
-
-  // Fetch all jobs matching base filters (select only location field for efficiency)
-  const allJobsSnapshot = await totalQuery
-    .orderBy('createdAt', 'desc')
-    .select('location')
-    .get()
-
-  // Count jobs matching location filter
-  const locationMatchCount = allJobsSnapshot.docs.filter((doc) => {
-    const docLocation = doc.data().location
-    return docLocation && docLocation.toLowerCase().includes(locationLower)
-  }).length
-
-  // Filter current page results by location
-  const filteredJobs = jobs.filter((job) => {
-    if (typeof job.location !== 'string') {
-      return false
-    }
-    return job.location.toLowerCase().includes(locationLower)
-  })
-
-  return { filteredJobs, filteredTotal: locationMatchCount }
-}
-
-function buildDemoJobs(): Job[] {
-  const now = new Date().toISOString()
-  const expiresAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString()
-
-  return [
-    {
-      id: 'demo-job-1',
-      title: 'Senior React Developer',
-      company: 'TechCorp Solutions',
-      type: 'full-time',
-      location: 'San Francisco, CA',
-      remote: true,
-      salary: { currency: 'USD', period: 'yearly', min: 120000, max: 180000 },
-      experience: 'senior',
-      description:
-        'Join our team building cutting-edge web applications with React, TypeScript, and Node.js.',
-      requirements: ['5+ years of React experience', 'Strong TypeScript skills', 'Experience with Node.js'],
-      status: 'published',
-      ownerId: 'demo-owner',
-      viewCount: 45,
-      applicationCount: 8,
-      createdAt: now,
-      updatedAt: now,
-      publishedAt: now,
-      expiresAt,
-    },
-    {
-      id: 'demo-job-2',
-      title: 'Full Stack Engineer',
-      company: 'StartupXYZ',
-      type: 'full-time',
-      location: 'Remote',
-      remote: true,
-      salary: { currency: 'USD', period: 'yearly', min: 90000, max: 140000 },
-      experience: 'mid',
-      description:
-        'Fast-growing startup seeking a versatile full stack engineer to help build our SaaS platform.',
-      requirements: ['3+ years full stack development', 'React and Node.js', 'PostgreSQL or similar'],
-      status: 'published',
-      ownerId: 'demo-owner',
-      viewCount: 67,
-      applicationCount: 12,
-      createdAt: now,
-      updatedAt: now,
-      publishedAt: now,
-      expiresAt,
-    },
-    {
-      id: 'demo-job-3',
-      title: 'Frontend Developer',
-      company: 'Design Studio Pro',
-      type: 'contract',
-      location: 'New York, NY',
-      remote: false,
-      salary: { currency: 'USD', period: 'hourly', min: 80, max: 120 },
-      experience: 'mid',
-      description:
-        'Creative agency looking for a talented frontend developer to join us for a 6-month contract.',
-      requirements: ['Strong HTML/CSS/JavaScript', 'React or Vue.js', 'Eye for design'],
-      status: 'published',
-      ownerId: 'demo-owner',
-      viewCount: 34,
-      applicationCount: 5,
-      createdAt: now,
-      updatedAt: now,
-      publishedAt: now,
-      expiresAt,
-    },
-  ] as Job[]
-}
-
-
 export async function GET(request: Request) {
   try {
     const filters = parseFilters(request)
@@ -218,54 +49,16 @@ export async function GET(request: Request) {
       assertActiveSubscription(auth)
     }
 
-    const baseQuery = buildJobsQuery(filters)
-    const offset = (filters.page - 1) * filters.limit
-    const paginatedQuery = baseQuery.orderBy('createdAt', 'desc').limit(filters.limit).offset(offset)
-
     try {
-      let jobs: Job[]
-      let usingLocalFallback = false
-
-      if (isFirebaseAdminFallbackMode) {
-        jobs = buildDemoJobs()
-        usingLocalFallback = true
-      } else {
-        const snapshot = await paginatedQuery.get()
-        jobs = snapshot.docs.map(transformJobDocument)
-      }
-
-      if (jobs.length === 0 && process.env.NODE_ENV === 'development') {
-        jobs = buildDemoJobs()
-        usingLocalFallback = true
-      }
-
-      // Handle location filter and count
-      let filteredJobs = jobs
-      let filteredTotal = jobs.length
-
-      if (filters.location) {
-        if (usingLocalFallback) {
-          const locationLower = filters.location.toLowerCase()
-          filteredJobs = jobs.filter((job) => job.location.toLowerCase().includes(locationLower))
-          filteredTotal = filteredJobs.length
-        } else {
-          const result = await handleLocationFiltering(jobs, baseQuery, filters.location)
-          filteredJobs = result.filteredJobs
-          filteredTotal = result.filteredTotal
-        }
-      } else if (!usingLocalFallback) {
-        // No location filter - use standard count query
-        const countSnapshot = await baseQuery.count().get()
-        filteredTotal = countSnapshot.data().count
-      }
+      const { jobs, total } = await listJobs(filters)
 
       return NextResponse.json({
-        jobs: filteredJobs,
+        jobs,
         pagination: {
           page: filters.page,
           limit: filters.limit,
-          total: filteredTotal,
-          pages: Math.ceil(filteredTotal / filters.limit),
+          total,
+          pages: Math.ceil(total / filters.limit),
         },
       })
     } catch (queryError) {
@@ -313,26 +106,6 @@ async function parseAndValidateJobPayload(request: Request) {
     throw new ApiError('Validation failed', 422, { issues: parsed.error.issues })
   }
   return parsed.data
-}
-
-async function createJob(
-  jobData: ReturnType<typeof jobFormSchema.parse>,
-  ownerId: string
-): Promise<Job> {
-  const now = new Date()
-  const newJobData = {
-    ...jobData,
-    ownerId,
-    viewCount: 0,
-    applicationCount: 0,
-    createdAt: now,
-    updatedAt: now,
-    publishedAt: jobData.status === 'published' ? now : null,
-  }
-
-  const docRef = await adminDb.collection('jobs').add(newJobData)
-  const doc = await docRef.get()
-  return transformJobDocument(doc)
 }
 
 export async function POST(request: Request) {

--- a/src/lib/server/__tests__/firestore.test.ts
+++ b/src/lib/server/__tests__/firestore.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Unit tests for shared server data-layer Firestore helpers.
+ *
+ * These helpers back the document transformers in jobs.ts and
+ * applications.ts, so their pass-through semantics must match the
+ * long-standing inline `value?.toDate?.() ?? value` behavior exactly.
+ */
+
+import { isMissingIndexError, toDateValue } from '../firestore'
+
+describe('toDateValue', () => {
+  it('converts Timestamp-like objects via toDate()', () => {
+    const date = new Date('2026-01-15T12:00:00Z')
+    const timestampLike = { toDate: () => date }
+
+    expect(toDateValue(timestampLike)).toBe(date)
+  })
+
+  it('passes Date instances through unchanged', () => {
+    const date = new Date('2026-01-15T12:00:00Z')
+
+    expect(toDateValue(date)).toBe(date)
+  })
+
+  it('passes strings through unchanged', () => {
+    expect(toDateValue('2026-01-15T12:00:00Z')).toBe('2026-01-15T12:00:00Z')
+  })
+
+  it('passes null and undefined through unchanged', () => {
+    expect(toDateValue(null)).toBeNull()
+    expect(toDateValue(undefined)).toBeUndefined()
+  })
+
+  it('passes plain objects without toDate through unchanged', () => {
+    const value = { seconds: 1700000000, nanoseconds: 0 }
+
+    expect(toDateValue(value)).toBe(value)
+  })
+})
+
+describe('isMissingIndexError', () => {
+  it('detects numeric failed-precondition code with index message', () => {
+    expect(
+      isMissingIndexError({
+        code: 9,
+        message: 'FAILED_PRECONDITION: The query requires an index.',
+      })
+    ).toBe(true)
+  })
+
+  it('detects string failed-precondition code with index message', () => {
+    expect(
+      isMissingIndexError({
+        code: 'failed-precondition',
+        message: 'The query requires an index. Create it here: ...',
+      })
+    ).toBe(true)
+  })
+
+  it('rejects failed-precondition errors unrelated to indexes', () => {
+    expect(
+      isMissingIndexError({
+        code: 9,
+        message: 'FAILED_PRECONDITION: some other constraint failed',
+      })
+    ).toBe(false)
+  })
+
+  it('rejects other error codes even with index wording', () => {
+    expect(
+      isMissingIndexError({
+        code: 13,
+        message: 'The query requires an index.',
+      })
+    ).toBe(false)
+  })
+
+  it('rejects non-object inputs', () => {
+    expect(isMissingIndexError(null)).toBe(false)
+    expect(isMissingIndexError(undefined)).toBe(false)
+    expect(isMissingIndexError('requires an index')).toBe(false)
+  })
+})

--- a/src/lib/server/applications.ts
+++ b/src/lib/server/applications.ts
@@ -1,0 +1,330 @@
+/**
+ * Server data layer: applications collection.
+ *
+ * All Firestore access for application documents lives here, including the
+ * transactional submission flow introduced in PR #190 (atomic application
+ * create + job counter increment). Route handlers keep HTTP concerns;
+ * functions here throw ApiError for handleApiError to translate.
+ *
+ * Extracted from the applications API routes with no intended behavior
+ * change (PR 3B).
+ */
+
+import { FieldValue } from 'firebase-admin/firestore'
+
+import { ApiError } from '@/lib/api/errors'
+import { adminAuth, adminDb } from '@/lib/firebase/admin'
+import {
+  applicationStatuses,
+  applicationStatusUpdateSchema,
+  applicationSubmissionSchema,
+} from '@/types'
+import type { Application } from '@/types'
+
+import { toDateValue } from './firestore'
+
+/** Validated application submission payload. */
+export type ApplicationSubmissionInput = ReturnType<typeof applicationSubmissionSchema.parse>
+
+/** Validated application status update payload. */
+export type ApplicationStatusUpdateInput = ReturnType<typeof applicationStatusUpdateSchema.parse>
+
+export type ApplicationListFilters = {
+  jobId?: string
+  seekerId?: string
+  ownerId?: string
+  status?: (typeof applicationStatuses)[number]
+  page: number
+  limit: number
+}
+
+export type ApplicationListResult = {
+  applications: Application[]
+  total: number
+}
+
+/**
+ * Converts a Firestore application document into the Application API model,
+ * normalizing Timestamp fields to Dates for JSON serialization.
+ */
+export function transformApplicationDocument(doc: FirebaseFirestore.DocumentSnapshot): Application {
+  const data = doc.data()!
+  return {
+    id: doc.id,
+    ...data,
+    createdAt: toDateValue(data.createdAt),
+    updatedAt: toDateValue(data.updatedAt),
+    reviewedAt: toDateValue(data.reviewedAt),
+  } as Application
+}
+
+function buildApplicationsQuery(filters: ApplicationListFilters): FirebaseFirestore.Query {
+  let query: FirebaseFirestore.Query = adminDb.collection('applications')
+
+  if (filters.jobId) {
+    query = query.where('jobId', '==', filters.jobId)
+  }
+  if (filters.seekerId) {
+    query = query.where('seekerId', '==', filters.seekerId)
+  }
+  if (filters.ownerId) {
+    query = query.where('ownerId', '==', filters.ownerId)
+  }
+  if (filters.status) {
+    query = query.where('status', '==', filters.status)
+  }
+
+  return query
+}
+
+/** Lists applications with pagination and total count. */
+export async function listApplications(
+  filters: ApplicationListFilters
+): Promise<ApplicationListResult> {
+  const offset = (filters.page - 1) * filters.limit
+
+  const snapshot = await buildApplicationsQuery(filters)
+    .orderBy('createdAt', 'desc')
+    .limit(filters.limit)
+    .offset(offset)
+    .get()
+
+  const countSnapshot = await buildApplicationsQuery(filters).count().get()
+  const total = countSnapshot.data().count
+
+  const applications = snapshot.docs.map(transformApplicationDocument)
+
+  return { applications, total }
+}
+
+/**
+ * Fetches a single application, ensuring the requester participates in it
+ * (as the applicant or the job owner).
+ */
+export async function getApplicationForParticipant(
+  applicationId: string,
+  requesterUid: string
+): Promise<Application> {
+  const appRef = adminDb.collection('applications').doc(applicationId)
+  const doc = await appRef.get()
+
+  if (!doc.exists) {
+    throw new ApiError('Application not found', 404)
+  }
+
+  const appData = doc.data()!
+
+  // Ensure requester is either the seeker or the owner
+  if (appData.seekerId !== requesterUid && appData.ownerId !== requesterUid) {
+    throw new ApiError('You do not have permission to view this application', 403)
+  }
+
+  return transformApplicationDocument(doc)
+}
+
+/**
+ * Submits an application for a job on behalf of a seeker.
+ *
+ * Runs as a Firestore transaction so the application document creation and
+ * the job's applicationCount increment are atomic. Duplicate submissions are
+ * rejected both via the deterministic `${jobId}_${seekerUid}` document ID and
+ * a legacy-compatible jobId/seekerId lookup.
+ */
+export async function submitApplication(
+  jobId: string,
+  seekerUid: string,
+  payload: ApplicationSubmissionInput
+): Promise<Application> {
+  // Get seeker details
+  const userRecord = await adminAuth.getUser(seekerUid)
+
+  const jobRef = adminDb.collection('jobs').doc(jobId)
+  // Deterministic ID makes a duplicate application a same-document conflict
+  const appRef = adminDb.collection('applications').doc(`${jobId}_${seekerUid}`)
+  const now = new Date()
+
+  // Create application and increment the counter atomically
+  await adminDb.runTransaction(async (transaction) => {
+    // Firestore transactions require all reads before any writes
+    const jobDoc = await transaction.get(jobRef)
+
+    if (!jobDoc.exists) {
+      throw new ApiError('Job not found', 404)
+    }
+
+    const job = jobDoc.data()!
+    if (job.status !== 'published') {
+      throw new ApiError('This job is not accepting applications', 400)
+    }
+
+    // Check if user has already applied
+    const existingAppDoc = await transaction.get(appRef)
+    if (existingAppDoc.exists) {
+      throw new ApiError('You have already applied to this job', 400)
+    }
+
+    // Legacy applications have auto-generated IDs, so the deterministic-ID
+    // check above cannot detect them — query by jobId/seekerId as well
+    const existingApplications = await transaction.get(
+      adminDb
+        .collection('applications')
+        .where('jobId', '==', jobId)
+        .where('seekerId', '==', seekerUid)
+        .limit(1),
+    )
+
+    if (!existingApplications.empty) {
+      throw new ApiError('You have already applied to this job', 400)
+    }
+
+    const applicationData = {
+      jobId,
+      seekerId: seekerUid,
+      ownerId: job.ownerId,
+      coverLetter: payload.coverLetter || null,
+      phone: payload.phone || null,
+      jobTitle: job.title,
+      company: job.company,
+      seekerName: userRecord.displayName || 'Anonymous',
+      seekerEmail: userRecord.email || '',
+      status: 'pending' as const,
+      createdAt: now,
+      updatedAt: now,
+    }
+
+    transaction.create(appRef, applicationData)
+    transaction.update(jobRef, {
+      applicationCount: FieldValue.increment(1),
+    })
+  })
+
+  // Retrieve the created application
+  const appDoc = await appRef.get()
+  return transformApplicationDocument(appDoc)
+}
+
+/**
+ * Updates an application's status (and reviewer notes) after verifying the
+ * requester owns the linked job. Sets reviewedAt on the first transition out
+ * of pending.
+ */
+export async function updateApplicationStatus(
+  applicationId: string,
+  ownerUid: string,
+  update: ApplicationStatusUpdateInput
+): Promise<Application> {
+  const appRef = adminDb.collection('applications').doc(applicationId)
+  const doc = await appRef.get()
+
+  if (!doc.exists) {
+    throw new ApiError('Application not found', 404)
+  }
+
+  const appData = doc.data()!
+
+  // Verify the authenticated owner manages the linked job
+  if (appData.ownerId !== ownerUid) {
+    throw new ApiError('You do not have permission to update this application', 403)
+  }
+
+  const now = new Date()
+  const updates: Partial<Application> = {
+    status: update.status,
+    notes: update.notes,
+    updatedAt: now,
+  }
+
+  // Set reviewedAt if status is being changed from pending and reviewedAt is not set
+  if (appData.status === 'pending' && update.status !== 'pending' && !appData.reviewedAt) {
+    updates.reviewedAt = now
+  }
+
+  await appRef.update(updates)
+
+  // Retrieve updated document
+  const updatedDoc = await appRef.get()
+  return transformApplicationDocument(updatedDoc)
+}
+
+/**
+ * Raw export data for an owner's applications. The discriminated result lets
+ * the export route keep its distinct 404 responses ("no jobs" vs "no
+ * applications") byte-for-byte identical.
+ */
+export type OwnerApplicationsExportData =
+  | { kind: 'no-jobs' }
+  | { kind: 'no-applications' }
+  | {
+      kind: 'ok'
+      applications: FirebaseFirestore.DocumentData[]
+      jobTitles: Map<string, string>
+      seekers: Map<string, { email: string }>
+    }
+
+/**
+ * Collects every application across the owner's jobs, plus job titles and
+ * seeker emails, for CSV export. Timestamp fields are returned raw; the CSV
+ * layer owns formatting.
+ */
+export async function getOwnerApplicationsExportData(
+  ownerUid: string
+): Promise<OwnerApplicationsExportData> {
+  // Fetch all jobs owned by user
+  const jobsSnapshot = await adminDb
+    .collection('jobs')
+    .where('ownerId', '==', ownerUid)
+    .get()
+
+  if (jobsSnapshot.empty) {
+    return { kind: 'no-jobs' }
+  }
+
+  const jobIds = jobsSnapshot.docs.map((doc) => doc.id)
+  const jobTitles = new Map<string, string>()
+  for (const doc of jobsSnapshot.docs) {
+    jobTitles.set(doc.id, doc.data().title)
+  }
+
+  // Fetch all applications for these jobs
+  // Note: Firestore 'in' queries support up to 10 items, so batch if needed
+  const applications: FirebaseFirestore.DocumentData[] = []
+
+  for (let i = 0; i < jobIds.length; i += 10) {
+    const batch = jobIds.slice(i, i + 10)
+    const applicationsSnapshot = await adminDb
+      .collection('applications')
+      .where('jobId', 'in', batch)
+      .orderBy('createdAt', 'desc')
+      .get()
+
+    applications.push(...applicationsSnapshot.docs.map((doc) => ({
+      id: doc.id,
+      ...doc.data(),
+    })))
+  }
+
+  if (applications.length === 0) {
+    return { kind: 'no-applications' }
+  }
+
+  // Fetch seeker details (email) for each application
+  const seekerIds = [...new Set(applications.map((app) => app.seekerId as string))]
+  const seekers = new Map<string, { email: string }>()
+
+  for (const seekerId of seekerIds) {
+    try {
+      const seekerDoc = await adminDb.collection('users').doc(seekerId).get()
+      if (seekerDoc.exists) {
+        const seekerData = seekerDoc.data()
+        seekers.set(seekerId, {
+          email: seekerData?.email || 'N/A',
+        })
+      }
+    } catch (error) {
+      console.error(`Failed to fetch seeker ${seekerId}:`, error)
+      seekers.set(seekerId, { email: 'N/A' })
+    }
+  }
+
+  return { kind: 'ok', applications, jobTitles, seekers }
+}

--- a/src/lib/server/firestore.ts
+++ b/src/lib/server/firestore.ts
@@ -1,0 +1,46 @@
+/**
+ * Shared Firestore helpers for the server data layer.
+ *
+ * These utilities are intentionally framework-free: no Next.js imports, no
+ * request/response handling. They exist so route handlers and data modules
+ * share one implementation of common Firestore concerns.
+ */
+
+/**
+ * Converts a Firestore Timestamp-like value to a JavaScript Date.
+ *
+ * Mirrors the long-standing inline pattern `value?.toDate?.() ?? value`:
+ * - Timestamp instances are converted via `toDate()`
+ * - Dates, strings, null, and undefined pass through unchanged
+ */
+export function toDateValue<T>(value: T): Date | T {
+  if (
+    value !== null &&
+    typeof value === 'object' &&
+    typeof (value as { toDate?: unknown }).toDate === 'function'
+  ) {
+    return (value as unknown as { toDate(): Date }).toDate()
+  }
+  return value
+}
+
+/**
+ * Detects the Firestore "missing composite index" failure mode.
+ *
+ * Used by list endpoints to fail fast with an actionable 503 instead of
+ * surfacing an opaque 500 (see jobs route error handling).
+ */
+export function isMissingIndexError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') {
+    return false
+  }
+
+  const code = (error as { code?: unknown }).code
+  const message = (error as { message?: unknown }).message
+  const normalizedMessage = typeof message === 'string' ? message.toLowerCase() : ''
+
+  return (
+    (code === 9 || code === 'failed-precondition') &&
+    normalizedMessage.includes('requires an index')
+  )
+}

--- a/src/lib/server/jobs.ts
+++ b/src/lib/server/jobs.ts
@@ -1,0 +1,348 @@
+/**
+ * Server data layer: jobs collection.
+ *
+ * All Firestore access for job documents lives here. Route handlers stay
+ * responsible for HTTP concerns (request parsing, auth guards, response
+ * shaping); this module owns queries, transactions, and document
+ * transformation. Functions throw ApiError so handleApiError can map
+ * failures to consistent HTTP responses.
+ *
+ * Extracted from src/app/api/jobs/route.ts and src/app/api/jobs/[id]/route.ts
+ * with no intended behavior change (PR 3B).
+ */
+
+import { FieldValue } from 'firebase-admin/firestore'
+
+import { ApiError } from '@/lib/api/errors'
+import { adminDb, isFirebaseAdminFallbackMode } from '@/lib/firebase/admin'
+import { jobFormSchema, jobStatuses, jobTypes } from '@/types'
+import type { Job } from '@/types'
+
+import { toDateValue } from './firestore'
+
+/** Validated job form payload (output of jobFormSchema). */
+export type JobFormInput = ReturnType<typeof jobFormSchema.parse>
+
+export type JobListFilters = {
+  ownerId?: string
+  status?: (typeof jobStatuses)[number]
+  type?: (typeof jobTypes)[number]
+  location?: string
+  remote?: boolean
+  experience?: 'entry' | 'mid' | 'senior' | 'lead'
+  page: number
+  limit: number
+}
+
+export type JobListResult = {
+  jobs: Job[]
+  total: number
+}
+
+/**
+ * Converts a Firestore job document into the Job API model, normalizing
+ * Timestamp fields to Dates for JSON serialization.
+ */
+export function transformJobDocument(doc: FirebaseFirestore.DocumentSnapshot): Job {
+  const data = doc.data()!
+  return {
+    id: doc.id,
+    ...data,
+    createdAt: toDateValue(data.createdAt),
+    updatedAt: toDateValue(data.updatedAt),
+    publishedAt: toDateValue(data.publishedAt),
+    expiresAt: toDateValue(data.expiresAt),
+  } as Job
+}
+
+function buildJobsQuery(filters: JobListFilters): FirebaseFirestore.Query {
+  let query: FirebaseFirestore.Query = adminDb.collection('jobs')
+
+  // For public listing, only show published jobs unless ownerId filter is present
+  if (filters.ownerId) {
+    query = query.where('ownerId', '==', filters.ownerId)
+  } else {
+    query = query.where('status', '==', 'published')
+  }
+
+  // Apply additional filters
+  if (filters.status && filters.ownerId) {
+    // Only allow status filter if user is filtering their own jobs
+    query = query.where('status', '==', filters.status)
+  }
+  if (filters.type) {
+    query = query.where('type', '==', filters.type)
+  }
+  if (filters.remote !== undefined) {
+    query = query.where('remote', '==', filters.remote)
+  }
+  if (filters.experience) {
+    query = query.where('experience', '==', filters.experience)
+  }
+
+  return query
+}
+
+async function applyLocationFiltering(
+  jobs: Job[],
+  totalQuery: FirebaseFirestore.Query,
+  location: string
+) {
+  const locationLower = location.toLowerCase()
+
+  // Fetch all jobs matching base filters (select only location field for efficiency)
+  const allJobsSnapshot = await totalQuery
+    .orderBy('createdAt', 'desc')
+    .select('location')
+    .get()
+
+  // Count jobs matching location filter
+  const locationMatchCount = allJobsSnapshot.docs.filter((doc) => {
+    const docLocation = doc.data().location
+    return docLocation && docLocation.toLowerCase().includes(locationLower)
+  }).length
+
+  // Filter current page results by location
+  const filteredJobs = jobs.filter((job) => {
+    if (typeof job.location !== 'string') {
+      return false
+    }
+    return job.location.toLowerCase().includes(locationLower)
+  })
+
+  return { filteredJobs, filteredTotal: locationMatchCount }
+}
+
+function buildDemoJobs(): Job[] {
+  const now = new Date().toISOString()
+  const expiresAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString()
+
+  return [
+    {
+      id: 'demo-job-1',
+      title: 'Senior React Developer',
+      company: 'TechCorp Solutions',
+      type: 'full-time',
+      location: 'San Francisco, CA',
+      remote: true,
+      salary: { currency: 'USD', period: 'yearly', min: 120000, max: 180000 },
+      experience: 'senior',
+      description:
+        'Join our team building cutting-edge web applications with React, TypeScript, and Node.js.',
+      requirements: ['5+ years of React experience', 'Strong TypeScript skills', 'Experience with Node.js'],
+      status: 'published',
+      ownerId: 'demo-owner',
+      viewCount: 45,
+      applicationCount: 8,
+      createdAt: now,
+      updatedAt: now,
+      publishedAt: now,
+      expiresAt,
+    },
+    {
+      id: 'demo-job-2',
+      title: 'Full Stack Engineer',
+      company: 'StartupXYZ',
+      type: 'full-time',
+      location: 'Remote',
+      remote: true,
+      salary: { currency: 'USD', period: 'yearly', min: 90000, max: 140000 },
+      experience: 'mid',
+      description:
+        'Fast-growing startup seeking a versatile full stack engineer to help build our SaaS platform.',
+      requirements: ['3+ years full stack development', 'React and Node.js', 'PostgreSQL or similar'],
+      status: 'published',
+      ownerId: 'demo-owner',
+      viewCount: 67,
+      applicationCount: 12,
+      createdAt: now,
+      updatedAt: now,
+      publishedAt: now,
+      expiresAt,
+    },
+    {
+      id: 'demo-job-3',
+      title: 'Frontend Developer',
+      company: 'Design Studio Pro',
+      type: 'contract',
+      location: 'New York, NY',
+      remote: false,
+      salary: { currency: 'USD', period: 'hourly', min: 80, max: 120 },
+      experience: 'mid',
+      description:
+        'Creative agency looking for a talented frontend developer to join us for a 6-month contract.',
+      requirements: ['Strong HTML/CSS/JavaScript', 'React or Vue.js', 'Eye for design'],
+      status: 'published',
+      ownerId: 'demo-owner',
+      viewCount: 34,
+      applicationCount: 5,
+      createdAt: now,
+      updatedAt: now,
+      publishedAt: now,
+      expiresAt,
+    },
+  ] as Job[]
+}
+
+/**
+ * Lists jobs with pagination, optional filters, and total count.
+ *
+ * Preserves the demo/fallback behavior of the original route: demo jobs are
+ * served when the Admin SDK runs in fallback mode, or when the query returns
+ * empty in development.
+ *
+ * @throws Firestore errors (including missing-index failures) untransformed;
+ *         callers classify them via isMissingIndexError.
+ */
+export async function listJobs(filters: JobListFilters): Promise<JobListResult> {
+  const baseQuery = buildJobsQuery(filters)
+  const offset = (filters.page - 1) * filters.limit
+  const paginatedQuery = baseQuery.orderBy('createdAt', 'desc').limit(filters.limit).offset(offset)
+
+  let jobs: Job[]
+  let usingLocalFallback = false
+
+  if (isFirebaseAdminFallbackMode) {
+    jobs = buildDemoJobs()
+    usingLocalFallback = true
+  } else {
+    const snapshot = await paginatedQuery.get()
+    jobs = snapshot.docs.map(transformJobDocument)
+  }
+
+  if (jobs.length === 0 && process.env.NODE_ENV === 'development') {
+    jobs = buildDemoJobs()
+    usingLocalFallback = true
+  }
+
+  // Handle location filter and count
+  let filteredJobs = jobs
+  let filteredTotal = jobs.length
+
+  if (filters.location) {
+    if (usingLocalFallback) {
+      const locationLower = filters.location.toLowerCase()
+      filteredJobs = jobs.filter((job) => job.location.toLowerCase().includes(locationLower))
+      filteredTotal = filteredJobs.length
+    } else {
+      const result = await applyLocationFiltering(jobs, baseQuery, filters.location)
+      filteredJobs = result.filteredJobs
+      filteredTotal = result.filteredTotal
+    }
+  } else if (!usingLocalFallback) {
+    // No location filter - use standard count query
+    const countSnapshot = await baseQuery.count().get()
+    filteredTotal = countSnapshot.data().count
+  }
+
+  return { jobs: filteredJobs, total: filteredTotal }
+}
+
+/**
+ * Fetches a single job, enforcing draft visibility (only the owner may see
+ * drafts) and incrementing the view counter for published jobs.
+ *
+ * The returned Job reflects the pre-increment snapshot, matching the
+ * original route behavior.
+ */
+export async function getJob(jobId: string, viewerUid: string | null): Promise<Job> {
+  const jobRef = adminDb.collection('jobs').doc(jobId)
+  const doc = await jobRef.get()
+
+  if (!doc.exists) {
+    throw new ApiError('Job not found', 404)
+  }
+
+  const jobData = doc.data()!
+
+  // Enforce draft visibility: only owner can view draft jobs
+  if (jobData.status === 'draft' && jobData.ownerId !== viewerUid) {
+    throw new ApiError('Job not found', 404)
+  }
+
+  // Increment view count for published jobs
+  if (jobData.status === 'published') {
+    await jobRef.update({
+      viewCount: FieldValue.increment(1),
+    })
+  }
+
+  return transformJobDocument(doc)
+}
+
+/** Creates a job owned by ownerId and returns the stored document. */
+export async function createJob(jobData: JobFormInput, ownerId: string): Promise<Job> {
+  const now = new Date()
+  const newJobData = {
+    ...jobData,
+    ownerId,
+    viewCount: 0,
+    applicationCount: 0,
+    createdAt: now,
+    updatedAt: now,
+    publishedAt: jobData.status === 'published' ? now : null,
+  }
+
+  const docRef = await adminDb.collection('jobs').add(newJobData)
+  const doc = await docRef.get()
+  return transformJobDocument(doc)
+}
+
+/**
+ * Updates a job after verifying ownership. Sets publishedAt only on the
+ * draft-to-published transition.
+ */
+export async function updateJob(jobId: string, ownerId: string, jobData: JobFormInput): Promise<Job> {
+  const jobRef = adminDb.collection('jobs').doc(jobId)
+  const doc = await jobRef.get()
+
+  if (!doc.exists) {
+    throw new ApiError('Job not found', 404)
+  }
+
+  const existingJob = doc.data()!
+  if (existingJob.ownerId !== ownerId) {
+    throw new ApiError('You do not have permission to update this job', 403)
+  }
+
+  const now = new Date()
+  const wasPublished = existingJob.status === 'published'
+  const isNowPublished = jobData.status === 'published'
+
+  const updates = {
+    ...jobData,
+    updatedAt: now,
+    // Set publishedAt only if transitioning from draft to published
+    ...((!wasPublished && isNowPublished) && { publishedAt: now }),
+  }
+
+  await jobRef.update(updates)
+
+  const updatedDoc = await jobRef.get()
+  return transformJobDocument(updatedDoc)
+}
+
+/** Deletes a job after verifying ownership. */
+export async function deleteJob(jobId: string, ownerId: string): Promise<void> {
+  const jobRef = adminDb.collection('jobs').doc(jobId)
+  const doc = await jobRef.get()
+
+  if (!doc.exists) {
+    throw new ApiError('Job not found', 404)
+  }
+
+  const job = doc.data()!
+  if (job.ownerId !== ownerId) {
+    throw new ApiError('You do not have permission to delete this job', 403)
+  }
+
+  // Delete the job document
+  await jobRef.delete()
+
+  // Optional: Delete associated applications (consider this for production)
+  // const applicationsRef = adminDb.collection('applications')
+  // const applicationsSnapshot = await applicationsRef.where('jobId', '==', id).get()
+  // const batch = adminDb.batch()
+  // applicationsSnapshot.docs.forEach(doc => batch.delete(doc.ref))
+  // await batch.commit()
+}

--- a/src/lib/server/users.ts
+++ b/src/lib/server/users.ts
@@ -1,0 +1,31 @@
+/**
+ * Server data layer: users collection.
+ *
+ * Read helpers for user profile documents. Writes happen through the auth
+ * flows (AuthContext document creation, initialize-claims route) and are out
+ * of scope for this module.
+ */
+
+import { adminDb } from '@/lib/firebase/admin'
+
+export interface UserRecordSummary {
+  exists: boolean
+  role: string | null
+}
+
+/**
+ * Fetches a user document and returns its role.
+ *
+ * Returns `{ exists: false, role: null }` when the document is missing so
+ * callers can distinguish "no such user" (404) from "wrong role" (403).
+ */
+export async function getUserRecordSummary(uid: string): Promise<UserRecordSummary> {
+  const doc = await adminDb.collection('users').doc(uid).get()
+
+  if (!doc.exists) {
+    return { exists: false, role: null }
+  }
+
+  const role = doc.data()?.role
+  return { exists: true, role: typeof role === 'string' ? role : null }
+}


### PR DESCRIPTION
## Summary

Extracts all Firestore access from the job and application API route handlers into a dedicated server data layer under `src/lib/server/`. Route handlers now own HTTP concerns only (request parsing, auth guards, response shaping); queries, transactions, and document transformation live in one place.

No intended behavior change: response shapes, status codes, error payloads, transaction semantics, demo/fallback behavior, and rate limiting are preserved.

## New modules

| Module | Exports |
|---|---|
| `src/lib/server/firestore.ts` | `toDateValue`, `isMissingIndexError` (shared helpers, unit tested) |
| `src/lib/server/jobs.ts` | `listJobs`, `getJob`, `createJob`, `updateJob`, `deleteJob`, `transformJobDocument` |
| `src/lib/server/applications.ts` | `listApplications`, `getApplicationForParticipant`, `submitApplication`, `updateApplicationStatus`, `getOwnerApplicationsExportData` |
| `src/lib/server/users.ts` | `getUserRecordSummary` |

## Routes refactored (6)

`api/jobs` (GET/POST), `api/jobs/[id]` (GET/PUT/DELETE), `api/jobs/[id]/apply` (POST, transactional submission from #190), `api/applications` (GET), `api/applications/[id]` (GET/PATCH), `api/applications/export` (GET CSV).

## Behavior preservation

- Data-layer functions throw `ApiError`; `handleApiError` maps them exactly as before. Both Zod error formats kept (`error.issues` on jobs POST, `error.format()` elsewhere).
- `getJob` returns the pre-increment snapshot (view counter incremented after read), matching the original.
- `submitApplication` keeps the #190 transaction byte-for-byte: deterministic `${jobId}_${uid}` doc ID, legacy duplicate query, atomic counter increment.
- Export route keeps its legacy manual auth and distinct 404s ("no jobs" vs "no applications") via a discriminated result; CSV formatting stays in the route.
- Four duplicated inline Timestamp→Date transforms consolidated into `toDateValue` with identical pass-through semantics.

## Evidence

- `tsc --noEmit`: clean
- `eslint src/lib/server src/lib/api src/app/api`: clean
- `jest src/lib/server`: 10/10 (clean-room Linux workspace at exact lockfile versions)
- Diff: 11 files, +875/-577; handlers shrank ~580 lines into the data layer
- CI (lint, unit, build, rules, smoke, a11y) runs on this PR

## Also in this branch

`docs/adr/0004-server-data-layer.md` records the design (boundaries, error model, alternatives, follow-ups), since no prior written spec for "PR 3B" existed.

## Follow-ups (separate PRs)

SSR for the job detail page reusing `getJob`; reuse `listJobs` in `sitemap.ts`; migrate export route to `verifyAuth`.