### PR TITLE
fix(api): harden application submit, job deletion, and export auth (SMP-108)

### DIFF
--- a/src/app/api/applications/export/route.ts
+++ b/src/app/api/applications/export/route.ts
@@ -52,7 +52,9 @@ export async function GET(request: NextRequest) {
     }
 
     const token = authHeader.substring(7)
-    const decodedToken = await adminAuth.verifyIdToken(token)
+    // checkRevoked=true aligns this route with verifyAuth: revoked or
+    // disabled accounts are rejected instead of passing signature checks
+    const decodedToken = await adminAuth.verifyIdToken(token, true)
     const userId = decodedToken.uid
 
     // 2. Verify user role (owner only)
@@ -159,8 +161,15 @@ export async function GET(request: NextRequest) {
   } catch (error) {
     console.error('CSV export error:', error)
 
-    // Don't expose internal errors to client
-    if (error instanceof Error && error.message.includes('auth')) {
+    // Don't expose internal errors to client. Firebase auth failures carry
+    // an `auth/...` code (e.g. auth/id-token-revoked) whose message does not
+    // always contain "auth", so check both.
+    const errorCode = (error as { code?: unknown }).code
+    const isAuthError =
+      (error instanceof Error && error.message.includes('auth')) ||
+      (typeof errorCode === 'string' && errorCode.startsWith('auth/'))
+
+    if (isAuthError) {
       return NextResponse.json(
         { error: 'Authentication failed', message: 'Please sign in and try again' },
         { status: 401 }

--- a/src/app/api/jobs/[id]/apply/route.ts
+++ b/src/app/api/jobs/[id]/apply/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 
 import { assertRole, verifyAuth } from '@/lib/api/auth'
 import { ApiError, handleApiError } from '@/lib/api/errors'
+import { applicationSubmitLimiter } from '@/lib/api/rate-limit'
 import { submitApplication } from '@/lib/server/applications'
 import { applicationSubmissionSchema } from '@/types'
 
@@ -20,6 +21,32 @@ export async function POST(request: Request, context: RouteContext) {
 
     const auth = await verifyAuth(request)
     assertRole(auth, 'seeker')
+
+    // Rate limit submissions per seeker (best-effort, in-memory per instance)
+    const rateLimitResult = await applicationSubmitLimiter.check(auth.uid)
+    if (!rateLimitResult.allowed) {
+      const retryAfter = Math.ceil((rateLimitResult.reset - Date.now()) / 1000)
+
+      return NextResponse.json(
+        {
+          error: 'Rate limit exceeded',
+          message: `You can submit up to 20 applications per hour. Please try again in ${Math.ceil(retryAfter / 60)} minutes.`,
+          retryAfter,
+          limit: 20,
+          remaining: 0,
+          reset: rateLimitResult.reset,
+        },
+        {
+          status: 429,
+          headers: {
+            'Retry-After': String(retryAfter),
+            'X-RateLimit-Limit': '20',
+            'X-RateLimit-Remaining': '0',
+            'X-RateLimit-Reset': String(rateLimitResult.reset),
+          },
+        }
+      )
+    }
 
     let payload: unknown
     try {

--- a/src/lib/api/rate-limit.ts
+++ b/src/lib/api/rate-limit.ts
@@ -218,3 +218,17 @@ export const csvExportLimiter = rateLimiter({
   windowMs: 60 * 60 * 1000, // 1 hour
   maxKeys: 1000, // Track up to 1000 unique users
 })
+
+/**
+ * Pre-configured rate limiter for job application submissions
+ * Limit: 20 submissions per hour per seeker
+ *
+ * Note: the store is in-memory and therefore per-serverless-instance on
+ * Vercel. Treat this as best-effort abuse damping, not a hard guarantee;
+ * a durable store is tracked in ADR 0004 follow-ups.
+ */
+export const applicationSubmitLimiter = rateLimiter({
+  maxRequests: 20,
+  windowMs: 60 * 60 * 1000, // 1 hour
+  maxKeys: 5000, // Track up to 5000 unique seekers
+})

--- a/src/lib/server/jobs.ts
+++ b/src/lib/server/jobs.ts
@@ -322,7 +322,14 @@ export async function updateJob(jobId: string, ownerId: string, jobData: JobForm
   return transformJobDocument(updatedDoc)
 }
 
-/** Deletes a job after verifying ownership. */
+/**
+ * Deletes a job after verifying ownership, cascading the delete to its
+ * applications so none are orphaned.
+ *
+ * Applications are deleted first: if a batch fails the job remains and the
+ * delete can simply be retried. Batches are capped at Firestore's 500-write
+ * limit, so the cascade is best-effort cleanup rather than a transaction.
+ */
 export async function deleteJob(jobId: string, ownerId: string): Promise<void> {
   const jobRef = adminDb.collection('jobs').doc(jobId)
   const doc = await jobRef.get()
@@ -336,13 +343,22 @@ export async function deleteJob(jobId: string, ownerId: string): Promise<void> {
     throw new ApiError('You do not have permission to delete this job', 403)
   }
 
+  // Delete associated applications first (no orphans on partial failure)
+  const applicationsSnapshot = await adminDb
+    .collection('applications')
+    .where('jobId', '==', jobId)
+    .select()
+    .get()
+
+  const applicationRefs = applicationsSnapshot.docs.map((appDoc) => appDoc.ref)
+  for (let i = 0; i < applicationRefs.length; i += 500) {
+    const batch = adminDb.batch()
+    for (const ref of applicationRefs.slice(i, i + 500)) {
+      batch.delete(ref)
+    }
+    await batch.commit()
+  }
+
   // Delete the job document
   await jobRef.delete()
-
-  // Optional: Delete associated applications (consider this for production)
-  // const applicationsRef = adminDb.collection('applications')
-  // const applicationsSnapshot = await applicationsRef.where('jobId', '==', id).get()
-  // const batch = adminDb.batch()
-  // applicationsSnapshot.docs.forEach(doc => batch.delete(doc.ref))
-  // await batch.commit()
 }


### PR DESCRIPTION
��Stacked on #195 (merge that first). Three behavioral gaps confirmed unintentional, each fixed as its own commit.

**1. `fix(api): rate limit application submissions`**
The apply endpoint had no limiter (CSV export already had 5/hour). Adds `applicationSubmitLimiter`   20/hour per seeker, sliding window   returning 429 with Retry-After and X-RateLimit headers. In-memory and per-instance on Vercel: best-effort abuse damping, not a hard guarantee (durable store tracked in ADR 0004 follow-ups).

**2. `fix(jobs): cascade delete applications when a job is deleted`**
`deleteJob` now removes the job's applications in 500-write batches **before** deleting the job document, so a partial failure leaves a retryable job rather than orphaned applications. Replaces the long-standing commented-out TODO. Note: applications orphaned by past deletes are not retroactively cleaned   candidate for the reconcile script.

**3. `fix(api): enforce token revocation check in CSV export auth`**
Export verified tokens without `checkRevoked` (drift from `verifyAuth`). Now `verifyIdToken(token, true)`, and the error mapper recognizes `auth/*` codes so revoked tokens return 401 instead of a generic 500.

## Evidence
- `tsc --noEmit`: clean
- `eslint`: clean
- `jest src/lib/server`: 10/10 (clean-room at lockfile versions)
- Changes are additive (429 responses, cascade) or strictly tightening (revocation check)

Merge order: #195 �! this �! docs PR.

---
Replaces #196, which was auto-closed when its stacked base branch (refactor/SMP-106-server-data-layer) was deleted on merge of #195. Same commits, retargeted to main.
