### PR TITLE
ci(actions): fix invalid YAML breaking security policy review workflow (SMP-110)

### DIFF
--- a/.github/workflows/security-policy-review.yml
+++ b/.github/workflows/security-policy-review.yml
@@ -72,29 +72,33 @@ jobs:
         if: failure()
         uses: actions/github-script@v7
         with:
+          # Body is built from an array: column-0 lines inside this block
+          # scalar are invalid YAML and broke workflow registration entirely
           script: |
             const fs = require('fs');
             const snykContent = fs.readFileSync('.snyk', 'utf8');
             const expiryDates = snykContent.match(/expires: ['"]([0-9]{4}-[0-9]{2}-[0-9]{2})/g) || [];
+            const repoUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}`;
 
-            const body = `## ⚠️ Snyk Security Policy Review Required
-
-The automated security policy review has detected that one or more Snyk suppressions are nearing expiration or have expired.
-
-**Action Required**:
-1. Review the [\`.snyk\` policy file](https://github.com/${{ github.repository }}/blob/main/.snyk)
-2. Re-evaluate suppressed security findings
-3. Update expiry dates or remove suppressions as appropriate
-4. Consult [docs/SECURITY.md](https://github.com/${{ github.repository }}/blob/main/docs/SECURITY.md) for security review guidelines
-
-**Expiry dates found**:
-${expiryDates.map(d => `- ${d.replace(/expires: ['"]/, '')}`).join('\n')}
-
-**Background**:
-Expiry dates on security suppressions prevent "set and forget" risk acceptance. This ensures security findings are periodically re-evaluated as the codebase and threat landscape evolve.
-
-cc: @${context.repo.owner}
-`;
+            const body = [
+              '## ⚠️ Snyk Security Policy Review Required',
+              '',
+              'The automated security policy review has detected that one or more Snyk suppressions are nearing expiration or have expired.',
+              '',
+              '**Action Required**:',
+              `1. Review the [\`.snyk\` policy file](${repoUrl}/blob/main/.snyk)`,
+              '2. Re-evaluate suppressed security findings',
+              '3. Update expiry dates or remove suppressions as appropriate',
+              `4. Consult [docs/SECURITY.md](${repoUrl}/blob/main/docs/SECURITY.md) for security review guidelines`,
+              '',
+              '**Expiry dates found**:',
+              ...expiryDates.map(d => `- ${d.replace(/expires: ['"]/, '')}`),
+              '',
+              '**Background**:',
+              'Expiry dates on security suppressions prevent "set and forget" risk acceptance. This ensures security findings are periodically re-evaluated as the codebase and threat landscape evolve.',
+              '',
+              `cc: @${context.repo.owner}`,
+            ].join('\n');
 
             // Check if an issue already exists
             const issues = await github.rest.issues.listForRepo({


### PR DESCRIPTION
## Root cause (chronic 0s startup failure, all of the last 50 runs)

`security-policy-review.yml` was **invalid YAML**: the `github-script` issue body was a JS template literal whose continuation lines sat at **column 0** inside the `script: |` block scalar. Column-0 content terminates the block scalar, after which YAML tries to parse `**Action Required**:` as a mapping key and fails (`js-yaml`: *multiline key may not be an implicit key, line 84*).

Because GitHub couldn't parse the file at all, it registered the workflow under its file path (no `name:`), created a 0-second `startup_failure` run on **every push** (even though triggers are schedule + dispatch only), and rejected `workflow_dispatch` with HTTP 422.

## Fix

- Issue body built from a joined string array, fully indented within the block scalar (also keeps the produced markdown unindented, so list items don't render as code blocks)
- `${{ github.repository }}` interpolation replaced with `context.repo.owner`/`context.repo.repo` inside the script
- No behavioral change to the expiry-check step

Verified locally with a strict YAML parse: name + `schedule`/`workflow_dispatch` triggers now resolve. After merge I'll confirm with a manual `gh workflow run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)