### PR TITLE
chore(security): re-verify and extend expired snyk suppressions to 2027-01-01

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -4,8 +4,8 @@
 ignore:
   'SNYK-JS-SHOPMATCHPRO-*':
     - 'src/lib/config/env-validator.ts':
-        reason: 'Documentation strings for environment variable validation, not actual secrets'
-        expires: '2026-01-01T00:00:00.000Z'
+        reason: 'Documentation strings for environment variable validation, not actual secrets. Re-verified 2026-06-11.'
+        expires: '2027-01-01T00:00:00.000Z'
 
 # Safe to ignore - test/demo credentials only
   'SNYK-JS-SHOPMATCHPRO-HARDCODED-PASSWORD':
@@ -17,14 +17,14 @@ ignore:
 # Already mitigated - domain validation implemented
   'SNYK-JS-SHOPMATCHPRO-OPEN-REDIRECT':
     - 'src/app/subscribe/page.tsx':
-        reason: 'URL validated against stripe.com domain and HTTPS protocol before redirect'
-        expires: '2026-01-01T00:00:00.000Z'
+        reason: 'URL validated against checkout.stripe.com hostname whitelist and HTTPS protocol before redirect. Re-verified 2026-06-11.'
+        expires: '2027-01-01T00:00:00.000Z'
 
 # Safe to ignore - false positive (blob URL, not user input)
   'SNYK-JS-SHOPMATCHPRO-DOM-XSS':
     - 'src/components/applications-export-button.tsx':
-        reason: 'Creates download link with blob URL from CSV data, not unsanitized user input. Uses createElement, not innerHTML.'
-        expires: '2026-01-01T00:00:00.000Z'
+        reason: 'Creates download link with blob URL from CSV data, not unsanitized user input. Uses createElement, not innerHTML. Re-verified 2026-06-11.'
+        expires: '2027-01-01T00:00:00.000Z'
 
 # Safe to ignore - server-side logging only
   'SNYK-JS-SHOPMATCHPRO-FORMAT-STRING':


### PR DESCRIPTION
## Summary

Quarterly security policy review per #201 (auto-filed by the newly repaired `security-policy-review.yml` workflow after #200). The three suppressions that expired `2026-01-01` were re-evaluated against current `main` — **all three rationales still hold**, so expiries are extended one year to `2027-01-01` with a re-verification note in each reason.

Supersedes #202 (same diff; branch/commit renamed to satisfy `Validate Branch Name` and `Validate Commit Messages`).

## Re-verification evidence

| Suppression | File | Finding |
|---|---|---|
| `SNYK-JS-SHOPMATCHPRO-*` | `src/lib/config/env-validator.ts` | Still contains only human-readable description strings (e.g. `'Stripe secret key (sk_test_*...)'`) used for validation error messages. No actual secret values. |
| `SNYK-JS-SHOPMATCHPRO-OPEN-REDIRECT` | `src/app/subscribe/page.tsx` | Mitigation intact: checkout URL parsed via `new URL()`, hostname checked against `['checkout.stripe.com']` whitelist, and `https:` protocol enforced before `window.location.href` redirect (lines 128–141). Reason text updated to reflect the exact hostname whitelist. |
| `SNYK-JS-SHOPMATCHPRO-DOM-XSS` | `src/components/applications-export-button.tsx` | Still a false positive: CSV download uses `URL.createObjectURL(blob)` + `document.createElement('a')` with `a.download`, then revokes the object URL. No `innerHTML`/`dangerouslySetInnerHTML`. |

## Notes

- The three no-expiry suppressions (test credentials, server-side logging, variable-name false positive) were left as-is — no expiry to review.
- `.snyk` validated locally with `js-yaml` (parses clean, all 6 ignore keys intact).
- On #202 the substantive checks already passed with this exact diff: Build and Test, Firestore Rules, Snyk security scan, CodeQL, Accessibility, Smoke Tests, FOSSA.

Closes #201