### PR TITLE
sec(api): enforce owner role on job create/update/delete (SMP-111)

### DIFF
--- a/src/app/api/jobs/[id]/route.ts
+++ b/src/app/api/jobs/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server'
 
-import { assertActiveSubscription, verifyAuth } from '@/lib/api/auth'
+import { assertActiveSubscription, assertRole, verifyAuth } from '@/lib/api/auth'
 import { ApiError, handleApiError } from '@/lib/api/errors'
 import { deleteJob, getJob, updateJob } from '@/lib/server/jobs'
 import { jobFormSchema } from '@/types'
@@ -48,6 +48,7 @@ export async function PUT(request: Request, context: RouteContext) {
     assertJobId(id)
 
     const auth = await verifyAuth(request)
+    assertRole(auth, 'owner')
     assertActiveSubscription(auth)
 
     let payload: unknown
@@ -79,6 +80,7 @@ export async function DELETE(request: Request, context: RouteContext) {
     assertJobId(id)
 
     const auth = await verifyAuth(request)
+    assertRole(auth, 'owner')
     assertActiveSubscription(auth)
 
     await deleteJob(id, auth.uid)

--- a/src/app/api/jobs/route.ts
+++ b/src/app/api/jobs/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server'
 
-import { assertActiveSubscription, verifyAuth } from '@/lib/api/auth'
+import { assertActiveSubscription, assertRole, verifyAuth } from '@/lib/api/auth'
 import { ApiError, handleApiError } from '@/lib/api/errors'
 import { isMissingIndexError } from '@/lib/server/firestore'
 import { createJob, listJobs, type JobListFilters } from '@/lib/server/jobs'
@@ -111,6 +111,9 @@ async function parseAndValidateJobPayload(request: Request) {
 export async function POST(request: Request) {
   try {
     const auth = await verifyAuth(request)
+    // Only owners may post jobs. The data layer uses the Admin SDK (bypassing
+    // firestore.rules), so this role gate must be enforced here too.
+    assertRole(auth, 'owner')
     assertActiveSubscription(auth)
 
     const jobPayload = await parseAndValidateJobPayload(request)


### PR DESCRIPTION
## Finding (HIGH — role gate bypass)
`POST /api/jobs` and `PUT`/`DELETE /api/jobs/[id]` checked `verifyAuth` + `assertActiveSubscription` but **never `assertRole(auth, 'owner')`**. The data layer (`createJob`/`updateJob`/`deleteJob`) uses the **Admin SDK**, which bypasses `firestore.rules` — so the rules' `hasRole('owner')` gate provides no protection on the API path.

**Exploit:** a user who signs up as `seeker` but obtains `subActive: true` (the subscribe page + checkout route have no role gate; the webhook sets `subActive` while preserving `role: 'seeker'`) can create, edit, and delete job postings — a path the rules were written to forbid.

## Fix
`assertRole(auth, 'owner')` on all three mutating job routes, mirroring the apply route's `assertRole(auth, 'seeker')`. Minimal, no behavior change for legitimate owners.

## Verified
typecheck ✅ · build ✅ · changed files lint clean. (Found via a deep adversarial authorization review; data-layer IDOR checks and Firestore rules were otherwise airtight.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)